### PR TITLE
Add error event listeners on all metric streams

### DIFF
--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -160,6 +160,11 @@ const PodiumPodlet = class PodiumPodlet {
             value: template,
             writable: true,
         });
+
+
+        this.metrics.on('error', error => {
+            this.log.error('Error emitted by metric stream in @podium/podlet module', error);
+        });
     }
 
     get [Symbol.toStringTag]() {


### PR DESCRIPTION
This adds error event listeners on the metric stream. Guards against errors in the stream.

