### PR TITLE
refactor: remove pointless lodash method

### DIFF
--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -9,7 +9,6 @@ const abslog = require('abslog');
 const objobj = require('objobj');
 const utils = require('@podium/utils');
 const Proxy = require('@podium/proxy');
-const merge = require('lodash.merge');
 const joi = require('joi');
 const template = require('./template');
 
@@ -122,15 +121,10 @@ const PodiumPodlet = class PodiumPodlet {
 
         Object.defineProperty(this, 'httpProxy', {
             enumerable: true,
-            value: new Proxy(
-                merge(
-                    {
-                        pathname: this._pathname,
-                        logger: this.log,
-                    },
-                    {}
-                )
-            ),
+            value: new Proxy({
+                pathname: this._pathname,
+                logger: this.log,
+            }),
         });
 
         Object.defineProperty(this, 'baseContext', {

--- a/package.json
+++ b/package.json
@@ -24,13 +24,12 @@
     "lint:format": "eslint --fix ."
   },
   "dependencies": {
-    "@podium/proxy": "3.0.3",
     "@metrics/client": "2.4.1",
+    "@podium/proxy": "3.0.3",
     "@podium/schemas": "3.0.0",
     "@podium/utils": "3.1.2",
     "abslog": "2.4.0",
     "joi": "14.3.1",
-    "lodash.merge": "^4.6.1",
     "objobj": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
No point in using `merge` when the source object is an empty object.