### PR TITLE
Use new schema to validate arguments

### DIFF
--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -3,13 +3,12 @@
 'use strict';
 
 const { HttpIncoming } = require('@podium/utils');
+const { validate } = require('@podium/schemas');
 const Metrics = require('@metrics/client');
-const schemas = require('@podium/schemas');
 const abslog = require('abslog');
 const objobj = require('objobj');
 const utils = require('@podium/utils');
 const Proxy = require('@podium/proxy');
-const joi = require('joi');
 
 const { template } = utils;
 
@@ -26,52 +25,28 @@ const PodiumPodlet = class PodiumPodlet {
         logger = undefined,
         development = false,
     } = {}) {
-        joi.attempt(
-            name,
-            schemas.manifest.name,
-            new Error(
-                `The value, "${name}", for the required argument "name" on the Podlet constructor is not defined or not valid.`,
-            ),
+        if (validate.name(name).error) throw new Error(
+            `The value, "${name}", for the required argument "name" on the Podlet constructor is not defined or not valid.`
         );
 
-        joi.attempt(
-            version,
-            schemas.manifest.version,
-            new Error(
-                `The value, "${version}", for the required argument "version" on the Podlet constructor is not defined or not valid.`,
-            ),
+        if (validate.version(version).error) throw new Error(
+            `The value, "${version}", for the required argument "version" on the Podlet constructor is not defined or not valid.`
         );
 
-        joi.attempt(
-            pathname,
-            schemas.manifest.uri,
-            new Error(
-                `The value, "${pathname}", for the required argument "pathname" on the Podlet constructor is not defined or not valid.`,
-            ),
+        if (validate.uri(pathname).error) throw new Error(
+            `The value, "${pathname}", for the required argument "pathname" on the Podlet constructor is not defined or not valid.`
         );
 
-        joi.attempt(
-            manifest,
-            schemas.manifest.uri,
-            new Error(
-                `The value, "${manifest}", for the optional argument "manifest" on the Podlet constructor is not valid.`,
-            ),
+        if (validate.uri(manifest).error) throw new Error(
+            `The value, "${manifest}", for the optional argument "manifest" on the Podlet constructor is not valid.`
         );
 
-        joi.attempt(
-            content,
-            schemas.manifest.content,
-            new Error(
-                `The value, "${content}", for the optional argument "content" on the Podlet constructor is not valid.`,
-            ),
+        if (validate.content(content).error) throw new Error(
+            `The value, "${content}", for the optional argument "content" on the Podlet constructor is not valid.`
         );
 
-        joi.attempt(
-            fallback,
-            schemas.manifest.fallback,
-            new Error(
-                `The value, "${fallback}", for the optional argument "fallback" on the Podlet constructor is not valid.`,
-            ),
+        if (validate.fallback(fallback).error) throw new Error(
+            `The value, "${fallback}", for the optional argument "fallback" on the Podlet constructor is not valid.`
         );
 
         Object.defineProperty(this, 'name', {
@@ -193,12 +168,8 @@ const PodiumPodlet = class PodiumPodlet {
             throw new Error('Value for "css" has already been set');
         }
 
-        joi.attempt(
-            value,
-            schemas.manifest.css,
-            new Error(
-                `Value on argument variable "value", "${value}", is not valid`,
-            ),
+        if (validate.css(value).error) throw new Error(
+            `Value on argument variable "value", "${value}", is not valid`,
         );
 
         this.cssRoute = this[_sanitize](value);
@@ -215,12 +186,8 @@ const PodiumPodlet = class PodiumPodlet {
             throw new Error('Value for "js" has already been set');
         }
 
-        joi.attempt(
-            value,
-            schemas.manifest.js,
-            new Error(
-                `Value on argument variable "value", "${value}", is not valid`,
-            ),
+        if (validate.js(value).error) throw new Error(
+            `Value on argument variable "value", "${value}", is not valid`,
         );
 
         this.jsRoute = this[_sanitize](value);
@@ -229,20 +196,12 @@ const PodiumPodlet = class PodiumPodlet {
     }
 
     proxy({ target = null, name = null } = {}) {
-        joi.attempt(
-            target,
-            schemas.manifest.uri,
-            new Error(
-                `Value on argument variable "target", "${target}", is not valid`,
-            ),
+        if (validate.uri(target).error) throw new Error(
+            `Value on argument variable "target", "${target}", is not valid`,
         );
 
-        joi.attempt(
-            name,
-            schemas.manifest.name,
-            new Error(
-                `Value on argument variable "name", "${name}", is not valid`,
-            ),
+        if (validate.name(name).error) throw new Error(
+            `Value on argument variable "name", "${name}", is not valid`,
         );
 
         if (Object.keys(this.proxyRoutes).length >= 4) {

--- a/package.json
+++ b/package.json
@@ -26,10 +26,9 @@
   "dependencies": {
     "@metrics/client": "2.4.1",
     "@podium/proxy": "^4.0.0-next",
-    "@podium/schemas": "3.0.0",
+    "@podium/schemas": "^4.0.0-next",
     "@podium/utils": "^4.0.0-next",
     "abslog": "2.4.0",
-    "joi": "14.3.1",
     "objobj": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@metrics/client": "2.4.1",
     "@podium/proxy": "^4.0.0-next",
-    "@podium/schemas": "^4.0.0-next",
+    "@podium/schemas": "^4.0.0-next.1",
     "@podium/utils": "^4.0.0-next",
     "abslog": "2.4.0",
     "objobj": "^1.0.0"


### PR DESCRIPTION
Follow ups https://github.com/podium-lib/issues/issues/9. Use the new JSON Schema to validate arguments.

**NOTE:** one test is failing due to the validation rule. Seems like the `uri` validator does accept empty values. Fixed in the schema: https://github.com/podium-lib/schemas/pull/6