### PR TITLE
Use the new .js and .css fields in the new schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,10 +372,8 @@ The route will then respond with something like:
     "version": "1.0.0",
     "content": "/",
     "fallback": "/fallback",
-    "assets": {
-        "js": "",
-        "css": ""
-    },
+    "css": [],
+    "js": [],
     "proxy": {}
 }
 ```

--- a/__tests__/podlet.js
+++ b/__tests__/podlet.js
@@ -411,7 +411,7 @@ test('.fallback() - constructor has "fallback" set with absolute URI - should re
 test('.css() - call method with no arguments - should return default value', () => {
     const podlet = new Podlet(DEFAULT_OPTIONS);
     const result = podlet.css();
-    expect(result).toEqual([]);
+    expect(result).toEqual('');
 });
 
 test('.css() - set legal value on "value" argument - should return set value', () => {
@@ -420,7 +420,7 @@ test('.css() - set legal value on "value" argument - should return set value', (
     const result = podlet.css({ value: '/foo/bar' });
     const parsed = podlet.toJSON();
 
-    expect(result).toEqual([{ type: "module", value: "/foo/bar" }]);
+    expect(result).toEqual('/foo/bar');
     expect(parsed.assets.css).toEqual('/foo/bar');
     expect(parsed.css).toEqual([{ type: "module", value: "/foo/bar" }]);
 });
@@ -434,7 +434,7 @@ test('.css() - set "prefix" argument to "true" - should prefix value returned by
     const result = podlet.css({ value: '/foo/bar', prefix: true });
     const parsed = podlet.toJSON();
 
-    expect(result).toEqual([{ type: "module", value: "/xyz/foo/bar" }]);
+    expect(result).toEqual('/xyz/foo/bar');
     expect(parsed.assets.css).toEqual('/foo/bar');
     expect(parsed.css).toEqual([{ type: "module", value: "/foo/bar" }]);
 });
@@ -462,7 +462,7 @@ test('.css() - call method with "value" argument, then call it a second time wit
     const podlet = new Podlet(DEFAULT_OPTIONS);
     podlet.css({ value: '/foo/bar' });
     const result = podlet.css();
-    expect(result).toEqual([{ type: "module", value: "/foo/bar" }]);
+    expect(result).toEqual('/foo/bar');
 });
 
 test('.css() - call method twice with a value for "value" argument - should throw', () => {
@@ -482,7 +482,7 @@ test('.css() - call method twice with a value for "value" argument - should thro
 test('.js() - call method with no arguments - should return default value', () => {
     const podlet = new Podlet(DEFAULT_OPTIONS);
     const result = podlet.js();
-    expect(result).toEqual([]);
+    expect(result).toEqual('');
 });
 
 test('.js() - set legal value on "value" argument - should return set value', () => {
@@ -491,7 +491,7 @@ test('.js() - set legal value on "value" argument - should return set value', ()
     const result = podlet.js({ value: '/foo/bar' });
     const parsed = podlet.toJSON();
 
-    expect(result).toEqual([{ type: "module", value: "/foo/bar" }]);
+    expect(result).toEqual('/foo/bar');
     expect(parsed.assets.js).toEqual('/foo/bar');
     expect(parsed.js).toEqual([{ type: "module", value: "/foo/bar" }]);
 });
@@ -505,7 +505,7 @@ test('.js() - set "prefix" argument to "true" - should prefix value returned by 
     const result = podlet.js({ value: '/foo/bar', prefix: true });
     const parsed = podlet.toJSON();
 
-    expect(result).toEqual([{ type: "module", value: "/xyz/foo/bar" }]);
+    expect(result).toEqual('/xyz/foo/bar');
     expect(parsed.assets.js).toEqual('/foo/bar');
     expect(parsed.js).toEqual([{ type: "module", value: "/foo/bar" }]);
 });
@@ -533,7 +533,7 @@ test('.js() - call method with "value" argument, then call it a second time with
     const podlet = new Podlet(DEFAULT_OPTIONS);
     podlet.js({ value: '/foo/bar' });
     const result = podlet.js();
-    expect(result).toEqual([{ type: "module", value: "/foo/bar" }]);
+    expect(result).toEqual('/foo/bar');
 });
 
 test('.js() - call method twice with a value for "value" argument - should throw', () => {
@@ -580,7 +580,7 @@ test('.middleware() - .css() is set with a value - should append value to "res.l
     await server.listen();
 
     const result = await server.get();
-    expect(result.response.podium.css).toEqual(podlet.css());
+    expect(result.response.podium.css).toEqual(podlet.toJSON().css);
 
     await server.close();
 });
@@ -604,7 +604,7 @@ test('.middleware() - .js() is set with a value - should append value to "res.lo
     await server.listen();
 
     const result = await server.get();
-    expect(result.response.podium.js).toEqual(podlet.js());
+    expect(result.response.podium.js).toEqual(podlet.toJSON().js);
 
     await server.close();
 });

--- a/__tests__/podlet.js
+++ b/__tests__/podlet.js
@@ -203,43 +203,45 @@ test('Podlet() - invalid value given to "fallback" argument - should throw', () 
 
 test('Podlet() - serialize default values - should set "name" to same as on constructor', () => {
     const podlet = new Podlet(DEFAULT_OPTIONS);
-    const result = JSON.parse(JSON.stringify(podlet));
+    const result = podlet.toJSON();
     expect(result.name).toEqual('foo');
 });
 
 test('Podlet() - serialize default values - should set "version" to same as on constructor', () => {
     const podlet = new Podlet(DEFAULT_OPTIONS);
-    const result = JSON.parse(JSON.stringify(podlet));
+    const result = podlet.toJSON();
     expect(result.version).toEqual('v1.0.0');
 });
 
 test('Podlet() - serialize default values - should set "content" to "/"', () => {
     const podlet = new Podlet(DEFAULT_OPTIONS);
-    const result = JSON.parse(JSON.stringify(podlet));
+    const result = podlet.toJSON();
     expect(result.content).toEqual('/');
 });
 
 test('Podlet() - serialize default values - should set "fallback" to empty String', () => {
     const podlet = new Podlet(DEFAULT_OPTIONS);
-    const result = JSON.parse(JSON.stringify(podlet));
+    const result = podlet.toJSON();
     expect(result.fallback).toEqual('');
 });
 
 test('Podlet() - serialize default values - should set "assets.js" to empty String', () => {
     const podlet = new Podlet(DEFAULT_OPTIONS);
-    const result = JSON.parse(JSON.stringify(podlet));
+    const result = podlet.toJSON();
     expect(result.assets.js).toEqual('');
+    expect(result.js).toEqual([]);
 });
 
 test('Podlet() - serialize default values - should set "assets.css" to empty String', () => {
     const podlet = new Podlet(DEFAULT_OPTIONS);
-    const result = JSON.parse(JSON.stringify(podlet));
+    const result = podlet.toJSON();
     expect(result.assets.css).toEqual('');
+    expect(result.css).toEqual([]);
 });
 
 test('Podlet() - serialize default values - should set "proxy" to empty Object', () => {
     const podlet = new Podlet(DEFAULT_OPTIONS);
-    const result = JSON.parse(JSON.stringify(podlet));
+    const result = podlet.toJSON();
     expect(result.proxy).toEqual({});
 });
 
@@ -300,7 +302,7 @@ test('.content() - call method - should return default value', () => {
     const podlet = new Podlet(DEFAULT_OPTIONS);
 
     const result = podlet.content();
-    const parsed = JSON.parse(JSON.stringify(podlet));
+    const parsed = podlet.toJSON();
 
     expect(result).toEqual('/');
     expect(parsed.content).toEqual('/');
@@ -314,7 +316,7 @@ test('.content() - constructor has "pathname" and "content" set - "prefix" argum
     const podlet = new Podlet(options);
 
     const result = podlet.content();
-    const parsed = JSON.parse(JSON.stringify(podlet));
+    const parsed = podlet.toJSON();
 
     expect(result).toEqual('/bar/foo.html');
     expect(parsed.content).toEqual('/bar/foo.html');
@@ -328,7 +330,7 @@ test('.content() - constructor has "pathname" and "content" set - "prefix" argum
     const podlet = new Podlet(options);
 
     const result = podlet.content({ prefix: true });
-    const parsed = JSON.parse(JSON.stringify(podlet));
+    const parsed = podlet.toJSON();
 
     expect(result).toEqual('/foo/bar/foo.html');
     expect(parsed.content).toEqual('/bar/foo.html');
@@ -341,7 +343,7 @@ test('.content() - constructor has "content" set with absolute URI - should retu
     const podlet = new Podlet(options);
 
     const result = podlet.content();
-    const parsed = JSON.parse(JSON.stringify(podlet));
+    const parsed = podlet.toJSON();
 
     expect(result).toEqual('http://somewhere.remote.com');
     expect(parsed.content).toEqual('http://somewhere.remote.com');
@@ -355,7 +357,7 @@ test('.fallback() - call method - should return default value', () => {
     const podlet = new Podlet(DEFAULT_OPTIONS);
 
     const result = podlet.fallback();
-    const parsed = JSON.parse(JSON.stringify(podlet));
+    const parsed = podlet.toJSON();
 
     expect(result).toEqual('');
     expect(parsed.fallback).toEqual('');
@@ -369,7 +371,7 @@ test('.fallback() - constructor has "pathname" and "fallback" set - "prefix" arg
     const podlet = new Podlet(options);
 
     const result = podlet.fallback();
-    const parsed = JSON.parse(JSON.stringify(podlet));
+    const parsed = podlet.toJSON();
 
     expect(result).toEqual('/bar/foo.html');
     expect(parsed.fallback).toEqual('/bar/foo.html');
@@ -383,7 +385,7 @@ test('.fallback() - constructor has "pathname" and "fallback" set - "prefix" arg
     const podlet = new Podlet(options);
 
     const result = podlet.fallback({ prefix: true });
-    const parsed = JSON.parse(JSON.stringify(podlet));
+    const parsed = podlet.toJSON();
 
     expect(result).toEqual('/foo/bar/foo.html');
     expect(parsed.fallback).toEqual('/bar/foo.html');
@@ -396,7 +398,7 @@ test('.fallback() - constructor has "fallback" set with absolute URI - should re
     const podlet = new Podlet(options);
 
     const result = podlet.fallback();
-    const parsed = JSON.parse(JSON.stringify(podlet));
+    const parsed = podlet.toJSON();
 
     expect(result).toEqual('http://somewhere.remote.com');
     expect(parsed.fallback).toEqual('http://somewhere.remote.com');
@@ -409,17 +411,18 @@ test('.fallback() - constructor has "fallback" set with absolute URI - should re
 test('.css() - call method with no arguments - should return default value', () => {
     const podlet = new Podlet(DEFAULT_OPTIONS);
     const result = podlet.css();
-    expect(result).toEqual('');
+    expect(result).toEqual([]);
 });
 
 test('.css() - set legal value on "value" argument - should return set value', () => {
     const podlet = new Podlet(DEFAULT_OPTIONS);
 
     const result = podlet.css({ value: '/foo/bar' });
-    const parsed = JSON.parse(JSON.stringify(podlet));
+    const parsed = podlet.toJSON();
 
-    expect(result).toEqual('/foo/bar');
+    expect(result).toEqual([{ type: "module", value: "/foo/bar" }]);
     expect(parsed.assets.css).toEqual('/foo/bar');
+    expect(parsed.css).toEqual([{ type: "module", value: "/foo/bar" }]);
 });
 
 test('.css() - set "prefix" argument to "true" - should prefix value returned by method, but not in manifest', () => {
@@ -429,17 +432,19 @@ test('.css() - set "prefix" argument to "true" - should prefix value returned by
     const podlet = new Podlet(options);
 
     const result = podlet.css({ value: '/foo/bar', prefix: true });
-    const parsed = JSON.parse(JSON.stringify(podlet));
+    const parsed = podlet.toJSON();
 
-    expect(result).toEqual('/xyz/foo/bar');
+    expect(result).toEqual([{ type: "module", value: "/xyz/foo/bar" }]);
     expect(parsed.assets.css).toEqual('/foo/bar');
+    expect(parsed.css).toEqual([{ type: "module", value: "/foo/bar" }]);
 });
 
 test('.css() - set legal absolute value on "value" argument - should set "css" to set value when serializing Object', () => {
     const podlet = new Podlet(DEFAULT_OPTIONS);
     podlet.css({ value: 'http://somewhere.remote.com' });
-    const result = JSON.parse(JSON.stringify(podlet));
+    const result = podlet.toJSON();
     expect(result.assets.css).toEqual('http://somewhere.remote.com');
+    expect(result.css).toEqual([{ type: "module", value: "http://somewhere.remote.com" }]);
 });
 
 test('.css() - set illegal value on "value" argument - should throw', () => {
@@ -457,7 +462,7 @@ test('.css() - call method with "value" argument, then call it a second time wit
     const podlet = new Podlet(DEFAULT_OPTIONS);
     podlet.css({ value: '/foo/bar' });
     const result = podlet.css();
-    expect(result).toEqual('/foo/bar');
+    expect(result).toEqual([{ type: "module", value: "/foo/bar" }]);
 });
 
 test('.css() - call method twice with a value for "value" argument - should throw', () => {
@@ -477,17 +482,18 @@ test('.css() - call method twice with a value for "value" argument - should thro
 test('.js() - call method with no arguments - should return default value', () => {
     const podlet = new Podlet(DEFAULT_OPTIONS);
     const result = podlet.js();
-    expect(result).toEqual('');
+    expect(result).toEqual([]);
 });
 
 test('.js() - set legal value on "value" argument - should return set value', () => {
     const podlet = new Podlet(DEFAULT_OPTIONS);
 
     const result = podlet.js({ value: '/foo/bar' });
-    const parsed = JSON.parse(JSON.stringify(podlet));
+    const parsed = podlet.toJSON();
 
-    expect(result).toEqual('/foo/bar');
+    expect(result).toEqual([{ type: "module", value: "/foo/bar" }]);
     expect(parsed.assets.js).toEqual('/foo/bar');
+    expect(parsed.js).toEqual([{ type: "module", value: "/foo/bar" }]);
 });
 
 test('.js() - set "prefix" argument to "true" - should prefix value returned by method, but not in manifest', () => {
@@ -497,17 +503,19 @@ test('.js() - set "prefix" argument to "true" - should prefix value returned by 
     const podlet = new Podlet(options);
 
     const result = podlet.js({ value: '/foo/bar', prefix: true });
-    const parsed = JSON.parse(JSON.stringify(podlet));
+    const parsed = podlet.toJSON();
 
-    expect(result).toEqual('/xyz/foo/bar');
+    expect(result).toEqual([{ type: "module", value: "/xyz/foo/bar" }]);
     expect(parsed.assets.js).toEqual('/foo/bar');
+    expect(parsed.js).toEqual([{ type: "module", value: "/foo/bar" }]);
 });
 
 test('.js() - set legal absolute value on "value" argument - should set "js" to set value when serializing Object', () => {
     const podlet = new Podlet(DEFAULT_OPTIONS);
     podlet.js({ value: 'http://somewhere.remote.com' });
-    const result = JSON.parse(JSON.stringify(podlet));
+    const result = podlet.toJSON();
     expect(result.assets.js).toEqual('http://somewhere.remote.com');
+    expect(result.js).toEqual([{ type: "module", value: "http://somewhere.remote.com" }]);
 });
 
 test('.js() - set illegal value on "value" argument - should throw', () => {
@@ -525,7 +533,7 @@ test('.js() - call method with "value" argument, then call it a second time with
     const podlet = new Podlet(DEFAULT_OPTIONS);
     podlet.js({ value: '/foo/bar' });
     const result = podlet.js();
-    expect(result).toEqual('/foo/bar');
+    expect(result).toEqual([{ type: "module", value: "/foo/bar" }]);
 });
 
 test('.js() - call method twice with a value for "value" argument - should throw', () => {
@@ -553,13 +561,13 @@ test('.middleware() - call method - should append podlet name on "res.locals.pod
     await server.close();
 });
 
-test('.middleware() - .css() is NOT set with a value - should append empty String to "res.locals.podium.css"', async () => {
+test('.middleware() - .css() is NOT set with a value - should append empty Array to "res.locals.podium.css"', async () => {
     const podlet = new Podlet(DEFAULT_OPTIONS);
     const server = new FakeServer(podlet);
     await server.listen();
 
     const result = await server.get();
-    expect(result.response.podium.css).toEqual('');
+    expect(result.response.podium.css).toEqual([]);
 
     await server.close();
 });
@@ -577,13 +585,13 @@ test('.middleware() - .css() is set with a value - should append value to "res.l
     await server.close();
 });
 
-test('.middleware() - .js() is NOT set with a value - should append empty String to "res.locals.podium.js"', async () => {
+test('.middleware() - .js() is NOT set with a value - should append empty Array to "res.locals.podium.js"', async () => {
     const podlet = new Podlet(DEFAULT_OPTIONS);
     const server = new FakeServer(podlet);
     await server.listen();
 
     const result = await server.get();
-    expect(result.response.podium.js).toEqual('');
+    expect(result.response.podium.js).toEqual([]);
 
     await server.close();
 });

--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -12,6 +12,7 @@ const Proxy = require('@podium/proxy');
 
 const { template } = utils;
 
+const _compabillity = Symbol('_compabillity');
 const _sanitize = Symbol('_sanitize');
 
 const PodiumPodlet = class PodiumPodlet {
@@ -74,13 +75,11 @@ const PodiumPodlet = class PodiumPodlet {
         });
 
         Object.defineProperty(this, 'cssRoute', {
-            value: '',
-            writable: true,
+            value: [],
         });
 
         Object.defineProperty(this, 'jsRoute', {
-            value: '',
-            writable: true,
+            value: [],
         });
 
         Object.defineProperty(this, 'proxyRoutes', {
@@ -161,10 +160,16 @@ const PodiumPodlet = class PodiumPodlet {
 
     css({ value = null, prefix = false } = {}) {
         if (!value) {
-            return this[_sanitize](this.cssRoute, prefix);
+            return this.cssRoute.map(obj => {
+                const v = obj.value;
+                return {
+                    value: this[_sanitize](v, prefix),
+                    type: obj.type
+                };
+            });
         }
 
-        if (this.cssRoute) {
+        if (this.cssRoute.length === 1) {
             throw new Error('Value for "css" has already been set');
         }
 
@@ -172,17 +177,32 @@ const PodiumPodlet = class PodiumPodlet {
             `Value on argument variable "value", "${value}", is not valid`,
         );
 
-        this.cssRoute = this[_sanitize](value);
+        this.cssRoute.push({
+            value: this[_sanitize](value),
+            type: 'module'
+        });
 
-        return this[_sanitize](this.cssRoute, prefix);
+        return this.cssRoute.map(obj => {
+            const v = obj.value;
+            return {
+                value: this[_sanitize](v, prefix),
+                type: obj.type
+            };
+        });
     }
 
     js({ value = null, prefix = false } = {}) {
         if (!value) {
-            return this[_sanitize](this.jsRoute, prefix);
+            return this.jsRoute.map(obj => {
+                const v = obj.value;
+                return {
+                    value: this[_sanitize](v, prefix),
+                    type: obj.type
+                };
+            });
         }
 
-        if (this.jsRoute) {
+        if (this.jsRoute.length === 1) {
             throw new Error('Value for "js" has already been set');
         }
 
@@ -190,9 +210,19 @@ const PodiumPodlet = class PodiumPodlet {
             `Value on argument variable "value", "${value}", is not valid`,
         );
 
-        this.jsRoute = this[_sanitize](value);
 
-        return this[_sanitize](this.jsRoute, prefix);
+        this.jsRoute.push({
+            value: this[_sanitize](value),
+            type: 'module'
+        });
+
+        return this.jsRoute.map(obj => {
+            const v = obj.value;
+            return {
+                value: this[_sanitize](v, prefix),
+                type: obj.type
+            };
+        });
     }
 
     proxy({ target = null, name = null } = {}) {
@@ -242,9 +272,11 @@ const PodiumPodlet = class PodiumPodlet {
             content: this.contentRoute,
             fallback: this.fallbackRoute,
             assets: {
-                js: this.jsRoute,
-                css: this.cssRoute,
+                js: this[_compabillity](this.jsRoute),
+                css: this[_compabillity](this.cssRoute),
             },
+            css: this.cssRoute,
+            js: this.jsRoute,
             proxy: this.proxyRoutes,
         };
     }
@@ -334,6 +366,13 @@ const PodiumPodlet = class PodiumPodlet {
                 : uri;
         }
         return uri;
+    }
+
+    // This is here only to cater for compabillity between version 3 and 4
+    // Can be removed when deprecation of the .assets terminated
+    [_compabillity](arr) {
+        const result = arr.map(obj => { return obj.value });
+        return (result.length === 0) ? '' : result[0];
     }
 };
 

--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -160,13 +160,8 @@ const PodiumPodlet = class PodiumPodlet {
 
     css({ value = null, prefix = false } = {}) {
         if (!value) {
-            return this.cssRoute.map(obj => {
-                const v = obj.value;
-                return {
-                    value: this[_sanitize](v, prefix),
-                    type: obj.type
-                };
-            });
+            const v = this[_compabillity](this.cssRoute);
+            return this[_sanitize](v, prefix);
         }
 
         if (this.cssRoute.length === 1) {
@@ -182,24 +177,13 @@ const PodiumPodlet = class PodiumPodlet {
             type: 'module'
         });
 
-        return this.cssRoute.map(obj => {
-            const v = obj.value;
-            return {
-                value: this[_sanitize](v, prefix),
-                type: obj.type
-            };
-        });
+        return this[_sanitize](value, prefix);
     }
 
     js({ value = null, prefix = false } = {}) {
         if (!value) {
-            return this.jsRoute.map(obj => {
-                const v = obj.value;
-                return {
-                    value: this[_sanitize](v, prefix),
-                    type: obj.type
-                };
-            });
+            const v = this[_compabillity](this.jsRoute);
+            return this[_sanitize](v, prefix);
         }
 
         if (this.jsRoute.length === 1) {
@@ -216,13 +200,7 @@ const PodiumPodlet = class PodiumPodlet {
             type: 'module'
         });
 
-        return this.jsRoute.map(obj => {
-            const v = obj.value;
-            return {
-                value: this[_sanitize](v, prefix),
-                type: obj.type
-            };
-        });
+        return this[_sanitize](value, prefix);
     }
 
     proxy({ target = null, name = null } = {}) {
@@ -284,8 +262,8 @@ const PodiumPodlet = class PodiumPodlet {
     async process(incoming) {
         incoming.view = this._view;
         incoming.name = this.name;
-        incoming.css = this.css();
-        incoming.js = this.js();
+        incoming.css = this.cssRoute;
+        incoming.js = this.jsRoute;
 
         // Determine if request comes from layout server or not
         if (

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "dependencies": {
     "@metrics/client": "2.4.1",
     "@podium/proxy": "^4.0.0-next.1",
-    "@podium/schemas": "^4.0.0-next.2",
-    "@podium/utils": "^4.0.0-next",
+    "@podium/schemas": "^4.0.0-next.3",
+    "@podium/utils": "^4.0.0-next.2",
     "abslog": "2.4.0",
     "objobj": "^1.0.0"
   },


### PR DESCRIPTION
This takes use of the new `js` and `css` properties at root in the new manifest schema. Its also made sure that the previous `assets.js` and `assets.css` properties is set as previously so version 3 layouts will be able to use the manifest from a version 4 podlet.

In other words; there will be a period when the manifest will contain duplicates to maintain backwards compabillity:

```json
{
    "name": "podletContent",
    "version": "2.0.0-1554932811522",
    "content": "/",
    "fallback": "/fallback",
    "assets": {
        "js": "/assets/module.js",
        "css": "/assets/module.css"
    },
    "css": [
        { "value": "/assets/module.css", "type": "module" }
    ],
    "js": [
        { "value": "/assets/module.js", "type": "module" }
    ],
    "proxy": {}
}
```