### PR TITLE
Return HttpIncoming

### DIFF
--- a/__tests__/podlet.js
+++ b/__tests__/podlet.js
@@ -1,11 +1,20 @@
 'use strict';
 
+const { template, HttpIncoming } = require('@podium/utils');
 const Metrics = require('@metrics/client');
 const express = require('express');
 const http = require('http');
 const url = require('url');
-const { template } = require('@podium/utils');
+
 const Podlet = require('../');
+
+const SIMPLE_REQ = {
+    headers: {},
+};
+
+const SIMPLE_RES = {
+    locals: {},
+};
 
 /**
  * Fake server utility
@@ -536,6 +545,17 @@ test('.js() - call method twice with a value for "value" argument - should throw
     expect(() => {
         podlet.js({ value: '/foo/bar' });
     }).toThrowError('Value for "js" has already been set');
+});
+
+// #############################################
+// .process()
+// #############################################
+
+test('.process() - call method with HttpIncoming - should return HttpIncoming', () => {
+    const podlet = new Podlet(DEFAULT_OPTIONS);
+    const incoming = new HttpIncoming(SIMPLE_REQ, SIMPLE_RES);
+    const result = podlet.process(incoming);
+    expect(result).toEqual(incoming);
 });
 
 // #############################################

--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -249,7 +249,7 @@ const PodiumPodlet = class PodiumPodlet {
         };
     }
 
-    async process(incoming) {
+    process(incoming) {
         incoming.view = this._view;
         incoming.name = this.name;
         incoming.css = this.css();
@@ -287,6 +287,8 @@ const PodiumPodlet = class PodiumPodlet {
                 )}"`,
             );
         }
+
+        return incoming;
     }
 
     render(incoming, data) {


### PR DESCRIPTION
Somewhere between (oldest) https://github.com/podium-lib/podlet/blob/f3493b6031c731fa45b6cc971604531a7ec9f9ee/lib/podlet.js#L293-L333 and (newest) https://github.com/podium-lib/podlet/blob/14df5a87e59c0e4878d138bfa284edc5f56df2e4/lib/podlet.js#L293-L331 `return incoming` have dissapeard from the `.process()` method.

The weird thing here is that the dissapearense does not show up in any of the commits (oldest) https://github.com/podium-lib/podlet/commit/f3493b6031c731fa45b6cc971604531a7ec9f9ee / (newest) https://github.com/podium-lib/podlet/commit/14df5a87e59c0e4878d138bfa284edc5f56df2e4 

This reintroduces that `.process()` returns `HttpIncoming`.