### PR TITLE
Fix for dev mode sending document when UA is set

### DIFF
--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -324,7 +324,7 @@ const PodiumPodlet = class PodiumPodlet {
     }
 
     render(incoming, data) {
-        if (!this.development) {
+        if (!incoming.development) {
             if (typeof data === 'string') return data;
             return data.body || '';
         }


### PR DESCRIPTION
This fixes a bug where the html document used in development in a podlet would be served when a layout requests it. This would cause a double html document in the final rendered html from the layout server.

This would only happen when a Podlet is in development mode and requested from layout server.
