### PR TITLE
Remove limitation of how many assets which can be set

### DIFF
--- a/__tests__/podlet.js
+++ b/__tests__/podlet.js
@@ -531,14 +531,14 @@ test('.css() - call method with "value" argument, then call it a second time wit
     expect(result).toEqual('/foo/bar');
 });
 
-test('.css() - call method twice with a value for "value" argument - should throw', () => {
-    expect.hasAssertions();
+test('.css() - call method twice - should set value twice', () => {
     const podlet = new Podlet(DEFAULT_OPTIONS);
     podlet.css({ value: '/foo/bar' });
+    podlet.css({ value: '/bar/foo' });
 
-    expect(() => {
-        podlet.css({ value: '/foo/bar' });
-    }).toThrowError('Value for "css" has already been set');
+    const result = podlet.toJSON();
+    expect(result.assets.css).toEqual('/foo/bar');
+    expect(result.css).toEqual([{ type: "module", value: "/foo/bar" }, { type: "module", value: "/bar/foo" }]);
 });
 
 // #############################################
@@ -602,14 +602,14 @@ test('.js() - call method with "value" argument, then call it a second time with
     expect(result).toEqual('/foo/bar');
 });
 
-test('.js() - call method twice with a value for "value" argument - should throw', () => {
-    expect.hasAssertions();
+test('.js() - call method twice - should set value twice', () => {
     const podlet = new Podlet(DEFAULT_OPTIONS);
     podlet.js({ value: '/foo/bar' });
+    podlet.js({ value: '/bar/foo' });
 
-    expect(() => {
-        podlet.js({ value: '/foo/bar' });
-    }).toThrowError('Value for "js" has already been set');
+    const result = podlet.toJSON();
+    expect(result.assets.js).toEqual('/foo/bar');
+    expect(result.js).toEqual([{ type: "module", value: "/foo/bar" }, { type: "module", value: "/bar/foo" }]);
 });
 
 // #############################################

--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -186,10 +186,6 @@ const PodiumPodlet = class PodiumPodlet {
             return this[_sanitize](v, prefix);
         }
 
-        if (this.cssRoute.length === 1) {
-            throw new Error('Value for "css" has already been set');
-        }
-
         if (validate.css(value).error) throw new Error(
             `Value on argument variable "value", "${value}", is not valid`,
         );
@@ -208,14 +204,9 @@ const PodiumPodlet = class PodiumPodlet {
             return this[_sanitize](v, prefix);
         }
 
-        if (this.jsRoute.length === 1) {
-            throw new Error('Value for "js" has already been set');
-        }
-
         if (validate.js(value).error) throw new Error(
             `Value on argument variable "value", "${value}", is not valid`,
         );
-
 
         this.jsRoute.push({
             value: this[_sanitize](value),


### PR DESCRIPTION
This removes the limitation of how many assets can be set. In v3.x this was limited to one asset (a bundle) but in v4 we opened for this being multiple. Until now we kept the limitation to one through the API for backwards compabillity but under further consideration it seems like we do not need to.

In other words; one can now do as follow:

```js
const podlet = new Podlet({ ... });
podlet.css({ value: 'a.css' });
podlet.css({ value: 'b.css' });
podlet.css({ value: 'c.css' });
```