### PR TITLE
Added type as argument to .js method

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,9 +380,10 @@ The route will then respond with something like:
 
 ### options
 
-| option | type      | default | required |
-| ------ | --------- | ------- | -------- |
-| prefix | `boolean` | `false` |          |
+| option | type      | default   | required |
+| ------ | --------- | --------- | -------- |
+| prefix | `boolean` | `false`   |          |
+| type   | `string`  | `default` |          |
 
 #### prefix
 
@@ -404,6 +405,11 @@ const podlet = new Podlet({
 
 podlet.manifest({ prefix: true });
 ```
+
+#### type
+
+Set the type of script which is set. `default` indicates an unknown type.
+`module` inidcates as ES6 module.
 
 ### .content(options)
 

--- a/__tests__/podlet.js
+++ b/__tests__/podlet.js
@@ -488,7 +488,7 @@ test('.css() - set legal value on "value" argument - should return set value', (
 
     expect(result).toEqual('/foo/bar');
     expect(parsed.assets.css).toEqual('/foo/bar');
-    expect(parsed.css).toEqual([{ type: "module", value: "/foo/bar" }]);
+    expect(parsed.css).toEqual([{ type: "default", value: "/foo/bar" }]);
 });
 
 test('.css() - set "prefix" argument to "true" - should prefix value returned by method, but not in manifest', () => {
@@ -502,7 +502,7 @@ test('.css() - set "prefix" argument to "true" - should prefix value returned by
 
     expect(result).toEqual('/xyz/foo/bar');
     expect(parsed.assets.css).toEqual('/foo/bar');
-    expect(parsed.css).toEqual([{ type: "module", value: "/foo/bar" }]);
+    expect(parsed.css).toEqual([{ type: "default", value: "/foo/bar" }]);
 });
 
 test('.css() - set legal absolute value on "value" argument - should set "css" to set value when serializing Object', () => {
@@ -510,7 +510,7 @@ test('.css() - set legal absolute value on "value" argument - should set "css" t
     podlet.css({ value: 'http://somewhere.remote.com' });
     const result = podlet.toJSON();
     expect(result.assets.css).toEqual('http://somewhere.remote.com');
-    expect(result.css).toEqual([{ type: "module", value: "http://somewhere.remote.com" }]);
+    expect(result.css).toEqual([{ type: "default", value: "http://somewhere.remote.com" }]);
 });
 
 test('.css() - set illegal value on "value" argument - should throw', () => {
@@ -538,7 +538,7 @@ test('.css() - call method twice - should set value twice', () => {
 
     const result = podlet.toJSON();
     expect(result.assets.css).toEqual('/foo/bar');
-    expect(result.css).toEqual([{ type: "module", value: "/foo/bar" }, { type: "module", value: "/bar/foo" }]);
+    expect(result.css).toEqual([{ type: "default", value: "/foo/bar" }, { type: "default", value: "/bar/foo" }]);
 });
 
 // #############################################
@@ -559,7 +559,7 @@ test('.js() - set legal value on "value" argument - should return set value', ()
 
     expect(result).toEqual('/foo/bar');
     expect(parsed.assets.js).toEqual('/foo/bar');
-    expect(parsed.js).toEqual([{ type: "module", value: "/foo/bar" }]);
+    expect(parsed.js).toEqual([{ type: "default", value: "/foo/bar" }]);
 });
 
 test('.js() - set "prefix" argument to "true" - should prefix value returned by method, but not in manifest', () => {
@@ -573,7 +573,7 @@ test('.js() - set "prefix" argument to "true" - should prefix value returned by 
 
     expect(result).toEqual('/xyz/foo/bar');
     expect(parsed.assets.js).toEqual('/foo/bar');
-    expect(parsed.js).toEqual([{ type: "module", value: "/foo/bar" }]);
+    expect(parsed.js).toEqual([{ type: "default", value: "/foo/bar" }]);
 });
 
 test('.js() - set legal absolute value on "value" argument - should set "js" to set value when serializing Object', () => {
@@ -581,7 +581,7 @@ test('.js() - set legal absolute value on "value" argument - should set "js" to 
     podlet.js({ value: 'http://somewhere.remote.com' });
     const result = podlet.toJSON();
     expect(result.assets.js).toEqual('http://somewhere.remote.com');
-    expect(result.js).toEqual([{ type: "module", value: "http://somewhere.remote.com" }]);
+    expect(result.js).toEqual([{ type: "default", value: "http://somewhere.remote.com" }]);
 });
 
 test('.js() - set illegal value on "value" argument - should throw', () => {
@@ -609,8 +609,19 @@ test('.js() - call method twice - should set value twice', () => {
 
     const result = podlet.toJSON();
     expect(result.assets.js).toEqual('/foo/bar');
-    expect(result.js).toEqual([{ type: "module", value: "/foo/bar" }, { type: "module", value: "/bar/foo" }]);
+    expect(result.js).toEqual([{ type: "default", value: "/foo/bar" }, { type: "default", value: "/bar/foo" }]);
 });
+
+test('.js() - "type" argument is set to "module" - should set "type" to "module"', () => {
+    const podlet = new Podlet(DEFAULT_OPTIONS);
+    podlet.js({ value: '/foo/bar' });
+    podlet.js({ value: '/bar/foo', type: 'module' });
+
+    const result = podlet.toJSON();
+    expect(result.assets.js).toEqual('/foo/bar');
+    expect(result.js).toEqual([{ type: "default", value: "/foo/bar" }, { type: "module", value: "/bar/foo" }]);
+});
+
 
 // #############################################
 // .process()

--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -192,13 +192,13 @@ const PodiumPodlet = class PodiumPodlet {
 
         this.cssRoute.push({
             value: this[_sanitize](value),
-            type: 'module'
+            type: 'default'
         });
 
         return this[_sanitize](value, prefix);
     }
 
-    js({ value = null, prefix = false } = {}) {
+    js({ value = null, prefix = false, type = 'default' } = {}) {
         if (!value) {
             const v = this[_compabillity](this.jsRoute);
             return this[_sanitize](v, prefix);
@@ -210,7 +210,7 @@ const PodiumPodlet = class PodiumPodlet {
 
         this.jsRoute.push({
             value: this[_sanitize](value),
-            type: 'module'
+            type,
         });
 
         return this[_sanitize](value, prefix);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@metrics/client": "2.4.1",
     "@podium/proxy": "4.0.0-next.2",
     "@podium/schemas": "4.0.0-next.3",
-    "@podium/utils": "4.0.0-next.3",
+    "@podium/utils": "4.0.0-next.4",
     "abslog": "2.4.0",
     "objobj": "^1.0.0"
   },


### PR DESCRIPTION
This adds `type` as argument to the `.js()` method. It also sets the default value to `default`. This will normally be used to define which type of script we have and can be used to reflect this in `<script>` tags.

Example: `type` set to `module` will set `<script type="module">` in the default template making it possible to load ES6 modules directly.