### PR TITLE
Made proxying in the process method configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,6 @@ app.use(async (req, res, next) => {
 
 | option   | default | type      | required | details                                                                   |
 | -------- | ------- | --------- | -------- | ------------------------------------------------------------------------- |
-| context  | `true`  | `boolean` | `false`  | If `@podium/context` should be applied as part of the `.process()` method |
 | proxy    | `true`  | `boolean` | `false`  | If `@podium/proxy` should be applied as part of the `.process()` method   |
 
 ### .middleware()

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Turns development mode on or off. See the section about development mode.
 
 The podlet instance has the following API:
 
-### .process(HttpIncoming)
+### .process(HttpIncoming, options)
 
 Method for processing a incoming HTTP request. This method is intended to be
 used to implement support for multiple HTTP frameworks and in most cases will not need to be
@@ -300,6 +300,13 @@ app.use(async (req, res, next) => {
     }
 });
 ```
+
+#### options
+
+| option   | default | type      | required | details                                                                   |
+| -------- | ------- | --------- | -------- | ------------------------------------------------------------------------- |
+| context  | `true`  | `boolean` | `false`  | If `@podium/context` should be applied as part of the `.process()` method |
+| proxy    | `true`  | `boolean` | `false`  | If `@podium/proxy` should be applied as part of the `.process()` method   |
 
 ### .middleware()
 

--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -272,9 +272,18 @@ const PodiumPodlet = class PodiumPodlet {
         };
     }
 
-    process(incoming) {
-        incoming.view = this._view;
+    render(incoming, data) {
+        if (!incoming.development) {
+            if (typeof data === 'string') return data;
+            return data.body || '';
+        }
+
+        return incoming.render(data);
+    }
+
+    async process(incoming, { proxy = true } = {}) {
         incoming.name = this.name;
+        incoming.view = this._view;
         incoming.css = this.cssRoute;
         incoming.js = this.jsRoute;
 
@@ -288,7 +297,7 @@ const PodiumPodlet = class PodiumPodlet {
             incoming.development = this.development;
         }
 
-        // Append development context and proxy
+        // Append development context
         if (incoming.development) {
             incoming.context = Object.assign(
                 this.baseContext,
@@ -311,16 +320,12 @@ const PodiumPodlet = class PodiumPodlet {
             );
         }
 
-        return incoming;
-    }
-
-    render(incoming, data) {
-        if (!incoming.development) {
-            if (typeof data === 'string') return data;
-            return data.body || '';
+        // Determin if the request should be proxied and do if so
+        if (incoming.development && proxy) {
+            await this.httpProxy.process(incoming);
         }
 
-        return incoming.render(data);
+        return incoming;
     }
 
     middleware() {
@@ -329,13 +334,10 @@ const PodiumPodlet = class PodiumPodlet {
 
             try {
                 await this.process(incoming);
+                // if this is a proxy request then no further work should be done.
+                if (incoming.proxy) return;
 
-                if (incoming.development) {
-                    await this.httpProxy.process(incoming);
-                    if (incoming.proxy) return; // proxy is handling request, nothing more to do
-                }
-
-                // set "state" on res.locals.podium
+                // set "incoming" on res.locals.podium
                 objobj.set('locals.podium', incoming, res);
 
                 if (res.header) {


### PR DESCRIPTION
This adds a options argument to the `podlet.process()` method with a `proxy` property which can be `true` or `false`.

The reason behind adding this it that inside the `podlet.process()` method we set sertain properties on `HttpIncoming` pluss calling the `proxy.process()` method for doing proxying. This works fine when doing setup as in a Express middelware, but in some http frameworks we need to separate the process of setting properties on `HttpIncoming` and setting up the proxy by calling `proxy.process()`. 

The new option property `proxy` makes it possible to turn the setup of proxying inside `podlet.proxess()` on or off making it easier to implement support for different http frameworks.