### PR TITLE
Use @podium/test-utils for destination stream

### DIFF
--- a/__tests__/podlet.js
+++ b/__tests__/podlet.js
@@ -1,9 +1,9 @@
 'use strict';
 
+const { destinationObjectStream } = require('@podium/test-utils');
 const { template, HttpIncoming } = require('@podium/utils');
 const Metrics = require('@metrics/client');
 const express = require('express');
-const stream = require('readable-stream');
 const http = require('http');
 const url = require('url');
 
@@ -15,24 +15,6 @@ const SIMPLE_REQ = {
 
 const SIMPLE_RES = {
     locals: {},
-};
-
-const destObjectStream = done => {
-    const arr = [];
-
-    const dStream = new stream.Writable({
-        objectMode: true,
-        write(chunk, encoding, callback) {
-            arr.push(chunk);
-            callback();
-        },
-    });
-
-    dStream.on('finish', () => {
-        done(arr);
-    });
-
-    return dStream;
 };
 
 /**
@@ -343,7 +325,7 @@ test('Podlet() - should collect metric with version info', done => {
 
     const podlet = new Podlet(DEFAULT_OPTIONS);
 
-    const dest = destObjectStream(arr => {
+    const dest = destinationObjectStream(arr => {
         expect(arr[0]).toMatchObject({
             name: 'podium_podlet_version_info',
             labels: [

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "objobj": "^1.0.0"
   },
   "devDependencies": {
+    "@podium/test-utils": "1.1.0",
     "eslint": "^5.15.3",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-config-prettier": "^4.1.0",
@@ -41,8 +42,7 @@
     "husky": "^1.3.1",
     "jest": "^24.5.0",
     "lint-staged": "^8.1.5",
-    "prettier": "^1.16.3",
-    "readable-stream": "^3.3.0"
+    "prettier": "^1.16.3"
   },
   "jest": {
     "coveragePathIgnorePatterns": [


### PR DESCRIPTION
Replaces the internal destination stream helper method with the one in @podium/test-utils.

