### PR TITLE
Refactor render method

### DIFF
--- a/__tests__/podlet.js
+++ b/__tests__/podlet.js
@@ -884,9 +884,11 @@ test('res.podiumSend() - contructor argument "development" is set to "true" - sh
     await server.listen();
     const result = await server.get({ raw: true });
 
+    const incoming = new HttpIncoming(SIMPLE_REQ, SIMPLE_RES);
     expect(result.response).toEqual(
-        template({ body: '<h1>OK!</h1>', title: DEFAULT_OPTIONS.name }),
+        template(incoming, '<h1>OK!</h1>')
     );
+
     await server.close();
 });
 
@@ -1095,7 +1097,7 @@ test('.view() - append a custom wireframe document - should render development o
     });
 
     const podlet = new Podlet(options);
-    podlet.view(str => `<div>${str.body}</div>`);
+    podlet.view((incoming, data) => `<div>${data}</div>`);
 
     const server = new FakeExpressServer(podlet, (req, res) => {
         res.podiumSend('<h1>OK!</h1>');

--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -272,18 +272,15 @@ const PodiumPodlet = class PodiumPodlet {
         };
     }
 
-    render(incoming, data) {
+    render(incoming, data, ...args) {
         if (!incoming.development) {
-            if (typeof data === 'string') return data;
-            return data.body || '';
+            return data;
         }
-
-        return incoming.render(data);
+        return this._view(incoming, data, ...args);
     }
 
     async process(incoming, { proxy = true } = {}) {
         incoming.name = this.name;
-        incoming.view = this._view;
         incoming.css = this.cssRoute;
         incoming.js = this.jsRoute;
 
@@ -344,7 +341,7 @@ const PodiumPodlet = class PodiumPodlet {
                     res.header('podlet-version', this.version);
                 }
 
-                res.podiumSend = data => res.send(this.render(incoming, data));
+                res.podiumSend = (data, ...args) => res.send(this.render(incoming, data, ...args));
 
                 next();
             } catch (error) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@metrics/client": "2.4.1",
     "@podium/proxy": "4.0.0-next.2",
     "@podium/schemas": "4.0.0-next.3",
-    "@podium/utils": "4.0.0-next.4",
+    "@podium/utils": "4.0.0-next.5",
     "abslog": "2.4.0",
     "objobj": "^1.0.0"
   },


### PR DESCRIPTION
This refactors the `.render()` method and how the document template is written. The main change here is that `HttpIncoming` is now passed on as the first argument to the document template and that the second argument is always a String intended to be the "body" of the document. 

We do also remove the `.render()` method on `HttpIncoming` and change the `.view` property to be a placeholder for properties intended to be used by the document template.

A document template does now have the following signature:

```js
const document = (incoming, data) => {
    return `
        <html>
            <head><title>${incoming.view.title}</title></head>
            <body>${data}</body>
        </html>
    `;
}
```

When rendering one will now do as follow:

```js
app.get('/', async (req, res, next) => {
    const incoming = res.locals.podium;

    incoming.view = {
        title: 'My Site / Travel / Hotels',
        gwt: '132458983736738'
    };
    
    const body = `<section>my content</section>`;

    res.podiumSend(body);
});
```

When calling the document template with the `.podiumSend()` method, the first argument, `incoming`, will be applied with the `HttpIncoming` object. The second argument to the document templatt function will be the first argument on `.podiumSend()`.

Though; its possible to pass on all parameters to the  `.podiumSend()` method to the document template. So a document template implementor can ex do like this:

```js
const document = (incoming, body, head) => {
    return `
        <html>
            <head><title>${incoming.view.title}</title>${head}</head>
            <body>${body}</body>
        </html>
    `;
}
```
And then use it like this:

```js
app.get('/', async (req, res, next) => {
    const incoming = res.locals.podium;

    incoming.view = {
        title: 'My Site / Travel / Hotels',
        gwt: '132458983736738'
    };

    const head = `<meta ..... />`;
    const body = `<section>my content</section>`;

    res.podiumSend(body, head);
});
```

The third and onwards parameters to the document template has no restrictions so they can be of any type the document template implementor feels like.

NB: This PR will not pass until https://github.com/podium-lib/utils/pull/12 is landed and published.