### PR TITLE
use pathnameBuilder to set publicPathname

### DIFF
--- a/__tests__/podlet.js
+++ b/__tests__/podlet.js
@@ -905,7 +905,7 @@ test('.defaults() - call method with no arguments - should return default value'
         locale: 'en-US',
         mountOrigin: '',
         mountPathname: '/',
-        publicPathname: '/',
+        publicPathname: '/podium-resource/foo',
         requestedBy: 'foo',
     });
 });
@@ -920,7 +920,7 @@ test('.defaults() - set value on "context" argument - should return set value', 
         locale: 'en-US',
         mountOrigin: '',
         mountPathname: '/',
-        publicPathname: '/',
+        publicPathname: '/podium-resource/foo',
         requestedBy: 'foo',
     });
 });
@@ -936,7 +936,7 @@ test('.defaults() - call method with "context" argument, then call it a second t
         locale: 'en-US',
         mountOrigin: '',
         mountPathname: '/',
-        publicPathname: '/',
+        publicPathname: '/podium-resource/foo',
         requestedBy: 'foo',
     });
 });
@@ -969,7 +969,9 @@ test('.defaults() - constructor argument "development" is to "true" - should app
     expect(result.response.podium.context.requestedBy).toEqual('foo');
     expect(result.response.podium.context.mountOrigin).toEqual(address);
     expect(result.response.podium.context.mountPathname).toEqual('/');
-    expect(result.response.podium.context.publicPathname).toEqual('/');
+    expect(result.response.podium.context.publicPathname).toEqual(
+        '/podium-resource/foo',
+    );
 
     await server.close();
 });
@@ -994,7 +996,9 @@ test('.defaults() - set "context" argument where a key overrides one existing co
     expect(result.response.podium.context.requestedBy).toEqual('foo');
     expect(result.response.podium.context.mountOrigin).toEqual(address);
     expect(result.response.podium.context.mountPathname).toEqual('/');
-    expect(result.response.podium.context.publicPathname).toEqual('/');
+    expect(result.response.podium.context.publicPathname).toEqual(
+        '/podium-resource/foo',
+    );
 
     await server.close();
 });
@@ -1020,7 +1024,9 @@ test('.defaults() - set "context" argument where a key is not a default context 
     expect(result.response.podium.context.requestedBy).toEqual('foo');
     expect(result.response.podium.context.mountOrigin).toEqual(address);
     expect(result.response.podium.context.mountPathname).toEqual('/');
-    expect(result.response.podium.context.publicPathname).toEqual('/');
+    expect(result.response.podium.context.publicPathname).toEqual(
+        '/podium-resource/foo',
+    );
 
     await server.close();
 });

--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-const { HttpIncoming } = require('@podium/utils');
+const { HttpIncoming, pathnameBuilder } = require('@podium/utils');
 const { validate } = require('@podium/schemas');
 const Metrics = require('@metrics/client');
 const abslog = require('abslog');
@@ -111,7 +111,11 @@ const PodiumPodlet = class PodiumPodlet {
                 requestedBy: this.name,
                 mountOrigin: '',
                 mountPathname: this._pathname,
-                publicPathname: this._pathname,
+                publicPathname: pathnameBuilder(
+                    this.httpProxy.pathname,
+                    this.httpProxy.prefix,
+                    this.name,
+                ),
             },
             writable: false,
         });


### PR DESCRIPTION
The `publicPathname` value on the development context was always being set to the podlet's pathname when the proxy was mounting proxies at pathname + prefix + name. 