### PR TITLE
Print deprecation message only on usage of the returned .js() and .css() value

### DIFF
--- a/__tests__/podlet.compabillity.js
+++ b/__tests__/podlet.compabillity.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const Podlet = require('../');
+
+const DEFAULT_OPTIONS = { name: 'foo', version: 'v1.0.0', pathname: '/' };
+
+// NB; these tests are here only to test compabillity between
+// V3 and V4 manifest changes. Can be removed when V3 manifest
+// support is removed.
+
+test('.js() - set legal value on "value" argument - should return set value', () => {
+    const podlet = new Podlet(DEFAULT_OPTIONS);
+
+    const result = podlet.js({ value: '/foo/bar' });
+    const parsed = podlet.toJSON();
+
+    expect(result).toEqual('/foo/bar');
+    expect(parsed.assets.js).toEqual('/foo/bar');
+    expect(parsed.js).toEqual([{ type: 'default', value: '/foo/bar' }]);
+});
+
+test('.js() - set "prefix" argument to "true" - should prefix value returned by method, but not in manifest', () => {
+    const options = Object.assign({}, DEFAULT_OPTIONS, {
+        pathname: '/xyz',
+    });
+    const podlet = new Podlet(options);
+
+    const result = podlet.js({ value: '/foo/bar', prefix: true });
+    const parsed = podlet.toJSON();
+
+    expect(result).toEqual('/xyz/foo/bar');
+    expect(parsed.assets.js).toEqual('/foo/bar');
+    expect(parsed.js).toEqual([{ type: 'default', value: '/foo/bar' }]);
+});
+
+
+test('.css() - set legal value on "value" argument - should return set value', () => {
+    const podlet = new Podlet(DEFAULT_OPTIONS);
+
+    const result = podlet.css({ value: '/foo/bar' });
+    const parsed = podlet.toJSON();
+
+    expect(result).toEqual('/foo/bar');
+    expect(parsed.assets.css).toEqual('/foo/bar');
+    expect(parsed.css).toEqual([{ type: 'default', value: '/foo/bar' }]);
+});
+
+test('.css() - set "prefix" argument to "true" - should prefix value returned by method, but not in manifest', () => {
+    const options = Object.assign({}, DEFAULT_OPTIONS, {
+        pathname: '/xyz',
+    });
+    const podlet = new Podlet(options);
+
+    const result = podlet.css({ value: '/foo/bar', prefix: true });
+    const parsed = podlet.toJSON();
+
+    expect(result).toEqual('/xyz/foo/bar');
+    expect(parsed.assets.css).toEqual('/foo/bar');
+    expect(parsed.css).toEqual([{ type: 'default', value: '/foo/bar' }]);
+});

--- a/__tests__/podlet.js
+++ b/__tests__/podlet.js
@@ -528,31 +528,6 @@ test('.css() - call method with no arguments - should return default value', () 
     expect(result).toEqual('');
 });
 
-test('.css() - set legal value on "value" argument - should return set value', () => {
-    const podlet = new Podlet(DEFAULT_OPTIONS);
-
-    const result = podlet.css({ value: '/foo/bar' });
-    const parsed = podlet.toJSON();
-
-    expect(result).toEqual('/foo/bar');
-    expect(parsed.assets.css).toEqual('/foo/bar');
-    expect(parsed.css).toEqual([{ type: 'default', value: '/foo/bar' }]);
-});
-
-test('.css() - set "prefix" argument to "true" - should prefix value returned by method, but not in manifest', () => {
-    const options = Object.assign({}, DEFAULT_OPTIONS, {
-        pathname: '/xyz',
-    });
-    const podlet = new Podlet(options);
-
-    const result = podlet.css({ value: '/foo/bar', prefix: true });
-    const parsed = podlet.toJSON();
-
-    expect(result).toEqual('/xyz/foo/bar');
-    expect(parsed.assets.css).toEqual('/foo/bar');
-    expect(parsed.css).toEqual([{ type: 'default', value: '/foo/bar' }]);
-});
-
 test('.css() - set legal absolute value on "value" argument - should set "css" to set value when serializing Object', () => {
     const podlet = new Podlet(DEFAULT_OPTIONS);
     podlet.css({ value: 'http://somewhere.remote.com' });
@@ -655,31 +630,6 @@ test('.js() - call method with no arguments - should return default value', () =
     const podlet = new Podlet(DEFAULT_OPTIONS);
     const result = podlet.js();
     expect(result).toEqual('');
-});
-
-test('.js() - set legal value on "value" argument - should return set value', () => {
-    const podlet = new Podlet(DEFAULT_OPTIONS);
-
-    const result = podlet.js({ value: '/foo/bar' });
-    const parsed = podlet.toJSON();
-
-    expect(result).toEqual('/foo/bar');
-    expect(parsed.assets.js).toEqual('/foo/bar');
-    expect(parsed.js).toEqual([{ type: 'default', value: '/foo/bar' }]);
-});
-
-test('.js() - set "prefix" argument to "true" - should prefix value returned by method, but not in manifest', () => {
-    const options = Object.assign({}, DEFAULT_OPTIONS, {
-        pathname: '/xyz',
-    });
-    const podlet = new Podlet(options);
-
-    const result = podlet.js({ value: '/foo/bar', prefix: true });
-    const parsed = podlet.toJSON();
-
-    expect(result).toEqual('/xyz/foo/bar');
-    expect(parsed.assets.js).toEqual('/foo/bar');
-    expect(parsed.js).toEqual([{ type: 'default', value: '/foo/bar' }]);
 });
 
 test('.js() - set legal absolute value on "value" argument - should set "js" to set value when serializing Object', () => {

--- a/lib/deprecations.js
+++ b/lib/deprecations.js
@@ -1,0 +1,58 @@
+'use strict';
+
+function cssDeprecated() {
+    if (!cssDeprecated.warned) {
+        cssDeprecated.warned = true;
+        process.emitWarning(
+            'Return value from method css() is now deprecated and will be removed in a future version. Please do not rely on this value.',
+            'DeprecationWarning',
+        );
+    }
+}
+
+function jsDeprecated() {
+    if (!jsDeprecated.warned) {
+        jsDeprecated.warned = true;
+        process.emitWarning(
+            'Return value from method js() is now deprecated and will be removed in a future version. Please do not rely on this value.',
+            'DeprecationWarning',
+        );
+    }
+}
+
+const CssDeprecation = class CssDeprecation extends String {
+    constructor(str) {
+        super(str);
+        this.v = str;
+    }
+
+    toString() {
+        cssDeprecated();
+        return this.v;
+    }
+
+    [Symbol.toPrimitive]() {
+        cssDeprecated();
+        return this.v;
+    }
+}
+
+const JsDeprecation = class JsDeprecation extends String {
+    constructor(str) {
+        super(str);
+        this.v = str;
+    }
+
+    toString() {
+        jsDeprecated();
+        return this.v;
+    }
+
+    [Symbol.toPrimitive]() {
+        jsDeprecated();
+        return this.v;
+    }
+}
+
+module.exports.CssDeprecation = CssDeprecation;
+module.exports.JsDeprecation = JsDeprecation;

--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -4,6 +4,7 @@
 
 'use strict';
 
+const { CssDeprecation, JsDeprecation } = require('./deprecations');
 const { HttpIncoming, pathnameBuilder } = require('@podium/utils');
 const { validate } = require('@podium/schemas');
 const Metrics = require('@metrics/client');
@@ -19,26 +20,6 @@ const _compabillity = Symbol('_compabillity');
 const _sanitize = Symbol('_sanitize');
 const _addCssAsset = Symbol('_addCssAsset');
 const _addJsAsset = Symbol('_addJsAsset');
-
-function deprecateJsReturn() {
-    if (!deprecateJsReturn.warned) {
-        deprecateJsReturn.warned = true;
-        process.emitWarning(
-            'Return value from method js() is now deprecated and will be removed in a future version. Please do not rely on this value.',
-            'DeprecationWarning',
-        );
-    }
-}
-
-function deprecateCssReturn() {
-    if (!deprecateCssReturn.warned) {
-        deprecateCssReturn.warned = true;
-        process.emitWarning(
-            'Return value from method css() is now deprecated and will be removed in a future version. Please do not rely on this value.',
-            'DeprecationWarning',
-        );
-    }
-}
 
 const PodiumPodlet = class PodiumPodlet {
     constructor({
@@ -232,8 +213,7 @@ const PodiumPodlet = class PodiumPodlet {
         });
 
         // deprecate
-        deprecateCssReturn();
-        return this[_sanitize](value, prefix);
+        return new CssDeprecation(this[_sanitize](value, prefix));
     }
 
     css(options = {}) {
@@ -270,8 +250,7 @@ const PodiumPodlet = class PodiumPodlet {
         });
 
         // deprecate
-        deprecateJsReturn();
-        return this[_sanitize](value, prefix);
+        return new JsDeprecation(this[_sanitize](value, prefix));
     }
 
     js(options = {}) {


### PR DESCRIPTION
From V3 to V4 we deprecated the return value from the `.js()` and `.css()` methods. In V5 we will remove that these return a value.

Due to this an deprecation message was added but the deprecation message is printed when these methods are used. Calling these methods to set a value will trigger the deprecation message which are not quite what we want. 

This little hack makes it so that the deprecation message is printed only when one try to use the returned value from these methods.

This will **not** trigger a deprecation message:

```js
const css = podlet.css({ value: '/public/css/main.css' });
```

This will trigger a deprecation message:

```js
const css = podlet.css({ value: '/public/css/main.css' });
app.get(css, (req, res) => {
    [ .... ]
});
```