### PR TITLE
Pass all arguments on to the asset classes

### DIFF
--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -195,23 +195,17 @@ const PodiumPodlet = class PodiumPodlet {
         return this[_sanitize](this.fallbackRoute, prefix);
     }
 
-    [_addCssAsset]({
-        value = null,
-        prefix = false
-    } = {}) {
-        if (!value) {
+    [_addCssAsset](options = {}) {
+        if (!options.value) {
             const v = this[_compabillity](this.cssRoute);
-            return this[_sanitize](v, prefix);
+            return this[_sanitize](v, options.prefix);
         }
 
-        this.cssRoute.push(new AssetCss({
-            pathname: this._pathname,
-            prefix,
-            value,
-        }));
+        const args = Object.assign({}, options, {pathname: this._pathname});
+        this.cssRoute.push(new AssetCss(args));
 
         // deprecate
-        return new CssDeprecation(this[_sanitize](value, prefix));
+        return new CssDeprecation(this[_sanitize](args.value, args.prefix));
     }
 
     css(options = {}) {
@@ -224,25 +218,17 @@ const PodiumPodlet = class PodiumPodlet {
         return this[_addCssAsset](options);
     }
 
-    [_addJsAsset]({
-        value = null,
-        prefix = false,
-        type,
-    } = {}) {
-        if (!value) {
+    [_addJsAsset](options = {}) {
+        if (!options.value) {
             const v = this[_compabillity](this.jsRoute);
-            return this[_sanitize](v, prefix);
+            return this[_sanitize](v, options.prefix);
         }
 
-        this.jsRoute.push(new AssetJs({
-            pathname: this._pathname,
-            prefix,
-            value,
-            type,
-        }));
+        const args = Object.assign({}, options, {pathname: this._pathname});
+        this.jsRoute.push(new AssetJs(args));
 
         // deprecate
-        return new JsDeprecation(this[_sanitize](value, prefix));
+        return new JsDeprecation(this[_sanitize](args.value, args.prefix));
     }
 
     js(options = {}) {


### PR DESCRIPTION
This makes sure that all arguments one set on the `.css()` and `.js()` methods is passed on to the new asset classes when instantiating new asset objects.

This is still a bit messy, but will be a lot cleaner when we can remove the backwards compatibility.