### PR TITLE
add typescript declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,57 @@
+import { HttpIncoming, AssetJs, AssetCss } from '@podium/utils';
+
+// Use declaration merging to extend Express.
+declare global {
+    namespace Express {
+        interface Response {
+            podiumSend(fragment: string, ...args: unknown[]): Response;
+        }
+    }
+}
+
+export interface PodletOptions {
+    name: string;
+    pathname: string;
+    version: string;
+    manifest?: string;
+    content?: string;
+    fallback?: string;
+    logger?: any;
+    development?: boolean;
+}
+
+export default class Podlet {
+    constructor(options: PodletOptions);
+
+    middleware(): (req: any, res: any, next: any) => Promise<void>;
+
+    manifest(options?: { prefix?: boolean }): string;
+
+    content(options?: { prefix?: boolean }): string;
+
+    fallback(options?: { prefix?: boolean }): string;
+
+    js(options: AssetJs | Array<AssetJs>): void;
+
+    css(options: AssetCss | Array<AssetCss>): void;
+
+    proxy(options: { target: string; name: string }): string;
+
+    defaults(context: any): any;
+
+    view(
+        template: (
+            incoming: HttpIncoming,
+            fragment: string,
+            ...args: unknown[]
+        ) => string,
+    ): void;
+
+    render(
+        incoming: HttpIncoming,
+        fragment: string,
+        ...args: unknown[]
+    ): string;
+
+    process(httpIncoming: HttpIncoming): Promise<HttpIncoming>;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -53,5 +53,5 @@ export default class Podlet {
         ...args: unknown[]
     ): string;
 
-    process(httpIncoming: HttpIncoming): Promise<HttpIncoming>;
+    process(incoming: HttpIncoming): Promise<HttpIncoming>;
 }

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
   },
   "homepage": "https://podium-lib.io/",
   "files": [
-    "lib"
+    "lib",
+    "index.d.ts"
   ],
+  "types": "index.d.ts",
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",


### PR DESCRIPTION
This pull request adds TypeScript declarations to this module.

Since we have first class support for Express I've added the `podiumSend` method to the express response type. This is achieved through [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html).

A minor issue is that the method doesn't exist unless the podlet's middleware has been hooked up in express, but we have no way of typing this (that I know of).

