### PR TITLE
Fix asset js and css methods

### DIFF
--- a/__tests__/podlet.compatibility.js
+++ b/__tests__/podlet.compatibility.js
@@ -4,7 +4,7 @@ const Podlet = require('../');
 
 const DEFAULT_OPTIONS = { name: 'foo', version: 'v1.0.0', pathname: '/' };
 
-// NB; these tests are here only to test compabillity between
+// NB; these tests are here only to test compatibility between
 // V3 and V4 manifest changes. Can be removed when V3 manifest
 // support is removed.
 

--- a/__tests__/podlet.js
+++ b/__tests__/podlet.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { destinationObjectStream } = require('@podium/test-utils');
-const { template, HttpIncoming } = require('@podium/utils');
+const { template, HttpIncoming, AssetJs, AssetCss } = require('@podium/utils');
 const Metrics = require('@metrics/client');
 const express = require('express');
 const http = require('http');
@@ -534,7 +534,11 @@ test('.css() - set legal absolute value on "value" argument - should set "css" t
     const result = JSON.parse(JSON.stringify(podlet));
     expect(result.assets.css).toEqual('http://somewhere.remote.com');
     expect(result.css).toEqual([
-        { rel: 'stylesheet', type: 'text/css', value: 'http://somewhere.remote.com' },
+        {
+            rel: 'stylesheet',
+            type: 'text/css',
+            value: 'http://somewhere.remote.com',
+        },
     ]);
 });
 
@@ -681,9 +685,7 @@ test('.js() - should NOT accept additional keys', () => {
 
     const result = JSON.parse(JSON.stringify(podlet));
     expect(result.assets.js).toEqual('/foo/bar');
-    expect(result.js).toEqual([
-        { type: 'default', value: '/foo/bar' },
-    ]);
+    expect(result.js).toEqual([{ type: 'default', value: '/foo/bar' }]);
 });
 
 test('.js() - "type" argument is set to "module" - should set "type" to "module"', () => {
@@ -871,6 +873,26 @@ test('.middleware() - .js() is set with a value - should append value to "res.lo
     expect(result.response.podium.js).toEqual(parsed.js);
 
     await server.close();
+});
+
+test('.js() - passing an instance of AssetsJs - should return set value', () => {
+    const podlet = new Podlet(DEFAULT_OPTIONS);
+
+    podlet.js(new AssetJs({ value: '/foo/bar', type: 'module' }));
+    const parsed = JSON.parse(JSON.stringify(podlet));
+
+    expect(parsed.assets.js).toEqual('/foo/bar');
+    expect(parsed.js[0].value).toEqual('/foo/bar');
+});
+
+test('.css() - passing an instance of AssetsCss - should return set value', () => {
+    const podlet = new Podlet(DEFAULT_OPTIONS);
+
+    podlet.css(new AssetCss({ value: '/foo/bar', type: 'text/css' }));
+    const parsed = JSON.parse(JSON.stringify(podlet));
+
+    expect(parsed.assets.css).toEqual('/foo/bar');
+    expect(parsed.css[0].value).toEqual('/foo/bar');
 });
 
 test('.middleware() - contructor argument "development" is NOT set and "user-agent" on request is NOT set to "@podium/client" - should append "false" value on "res.locals.podium.decorate"', async () => {

--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -5,7 +5,12 @@
 'use strict';
 
 const { CssDeprecation, JsDeprecation } = require('./deprecations');
-const { HttpIncoming, pathnameBuilder, AssetCss, AssetJs } = require('@podium/utils');
+const {
+    HttpIncoming,
+    pathnameBuilder,
+    AssetCss,
+    AssetJs,
+} = require('@podium/utils');
 const { validate } = require('@podium/schemas');
 const Metrics = require('@metrics/client');
 const abslog = require('abslog');
@@ -16,7 +21,7 @@ const pkg = require('../package.json');
 
 const { template } = utils;
 
-const _compabillity = Symbol('_compabillity');
+const _compatibility = Symbol('_compatibility');
 const _sanitize = Symbol('_sanitize');
 const _addCssAsset = Symbol('_addCssAsset');
 const _addJsAsset = Symbol('_addJsAsset');
@@ -197,11 +202,11 @@ const PodiumPodlet = class PodiumPodlet {
 
     [_addCssAsset](options = {}) {
         if (!options.value) {
-            const v = this[_compabillity](this.cssRoute);
+            const v = this[_compatibility](this.cssRoute);
             return this[_sanitize](v, options.prefix);
         }
 
-        const args = Object.assign({}, options, {pathname: this._pathname});
+        const args = Object.assign({}, options, { pathname: this._pathname });
         this.cssRoute.push(new AssetCss(args));
 
         // deprecate
@@ -220,11 +225,11 @@ const PodiumPodlet = class PodiumPodlet {
 
     [_addJsAsset](options = {}) {
         if (!options.value) {
-            const v = this[_compabillity](this.jsRoute);
+            const v = this[_compatibility](this.jsRoute);
             return this[_sanitize](v, options.prefix);
         }
 
-        const args = Object.assign({}, options, {pathname: this._pathname});
+        const args = Object.assign({}, options, { pathname: this._pathname });
         this.jsRoute.push(new AssetJs(args));
 
         // deprecate
@@ -290,8 +295,8 @@ const PodiumPodlet = class PodiumPodlet {
             content: this.contentRoute,
             fallback: this.fallbackRoute,
             assets: {
-                js: this[_compabillity](this.jsRoute),
-                css: this[_compabillity](this.cssRoute),
+                js: this[_compatibility](this.jsRoute),
+                css: this[_compatibility](this.cssRoute),
             },
             css: this.cssRoute,
             js: this.jsRoute,
@@ -390,7 +395,7 @@ const PodiumPodlet = class PodiumPodlet {
 
     // This is here only to cater for compabillity between version 3 and 4
     // Can be removed when deprecation of the .assets terminated
-    [_compabillity](arr) {
+    [_compatibility](arr) {
         const result = arr.map(obj => {
             const o = obj.toJSON();
             return o.value;

--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -206,7 +206,10 @@ const PodiumPodlet = class PodiumPodlet {
             return this[_sanitize](v, options.prefix);
         }
 
-        const args = Object.assign({}, options, { pathname: this._pathname });
+        const clonedOptions = JSON.parse(JSON.stringify(options));
+        const args = Object.assign({}, clonedOptions, {
+            pathname: this._pathname,
+        });
         this.cssRoute.push(new AssetCss(args));
 
         // deprecate
@@ -228,8 +231,8 @@ const PodiumPodlet = class PodiumPodlet {
             const v = this[_compatibility](this.jsRoute);
             return this[_sanitize](v, options.prefix);
         }
-
-        const args = Object.assign({}, options, { pathname: this._pathname });
+        const clonedOptions = JSON.parse(JSON.stringify(options));
+        const args = { ...clonedOptions, pathname: this._pathname };
         this.jsRoute.push(new AssetJs(args));
 
         // deprecate


### PR DESCRIPTION
I discovered that it was not possible to pass an instance of `AssetJs` to `.js()` nor an instance of `AssetCss` to `.css()` due to `Object.assign` not calling the instances `.toJSON` method. The easiest solution was to just clone the object using `JSON.parse(JSON.stringify(options))`. How do you feel about this approach? @trygve-lie 

Also, sorry about the formatting and renaming noise