### PR TITLE
Inherit URL values from Express

### DIFF
--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -361,6 +361,7 @@ const PodiumPodlet = class PodiumPodlet {
     middleware() {
         return async (req, res, next) => {
             const incoming = new HttpIncoming(req, res);
+            incoming.url = new URL(req.originalUrl, `${req.protocol}://${req.get('host')}`);
 
             try {
                 await this.process(incoming);


### PR DESCRIPTION
This make it so that we inherit the URL values from express and depend on those instead of parsing out these by our self.

The advantage of this is that we are then moving the responsibility of handling `x-forwarded` headers etc to Express and is not an extra thing in Podium. It improves security and makes the URL values in Express content and Podium identical.