### PR TITLE
Fix tests for node 14

### DIFF
--- a/tests/podlet.js
+++ b/tests/podlet.js
@@ -790,6 +790,7 @@ test('.process() - .process(HttpIncoming, { proxy: true }) - request to proxy pa
     const server = new FakeHttpServer({ podlet, process }, incoming => {
         if (incoming.url.pathname === '/podium-resource/foo/bar') {
             t.true(incoming.proxy);
+            if (incoming.proxy) return;
         }
 
         incoming.response.statusCode = 200;
@@ -816,6 +817,7 @@ test('.process() - .process(HttpIncoming, { proxy: false }) - request to proxy p
     const server = new FakeHttpServer({ podlet, process }, incoming => {
         if (incoming.url.pathname === '/podium-resource/foo/bar') {
             t.false(incoming.proxy);
+            if (incoming.proxy) return;
         }
 
         incoming.response.statusCode = 200;


### PR DESCRIPTION
Not 100% sure why some tests started to [fail on node 14](https://github.com/podium-lib/podlet/actions/runs/114686658) but my hunch is that its related to a fair bit of clean up in the streams event order in node 14. The reason for our tests starting to fail is probably a bug which has been masked / eaten by slightly uneven event order.

The error starting to occur on node 14 in one of our tests was:

```sh
          stack: |
            tests/podlet.js:796:27
            Server.<anonymous> (tests/podlet.js:39:19)
          at:
            line: 643
            column: 15
            file: _http_outgoing.js
            function: writeAfterEnd
          code: ERR_STREAM_WRITE_AFTER_END
          tapCaught: uncaughtException
          test: ".process() - .process(HttpIncoming, { proxy: true }) - request to proxy
            path - should do proxying"
```

The reason for the error is that in our test code, its written on the response after the proxy have written its data and ended the request.

Iow; if a request is proxied, the `incoming.proxy` value should be checked and one should not continue writing anything more on the response. This adds a check for such.