### PR TITLE
feat: Added support for data-* attributes on .js() method

### DIFF
--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -232,6 +232,19 @@ const PodiumPodlet = class PodiumPodlet {
         }
         const clonedOptions = JSON.parse(JSON.stringify(options));
         const args = { ...clonedOptions, pathname: this._pathname };
+
+        // Convert data attribute object structure to array of key value objects
+        if (typeof args.data === 'object' && args.data !== null) {
+            const data = [];
+            Object.keys(args.data).forEach((key) => {
+                data.push({
+                    value: args.data[key],
+                    key,
+                });
+            })
+            args.data = data;
+        }
+
         this.jsRoute.push(new AssetJs(args));
 
         // deprecate

--- a/tests/podlet.js
+++ b/tests/podlet.js
@@ -764,6 +764,37 @@ test('.js() - "options" argument as an array - should NOT set additional keys', 
     t.end()
 });
 
+test('.js() - data attribute object - should convert to array of key / value objects', (t) => {
+    const podlet = new Podlet(DEFAULT_OPTIONS);
+    podlet.js([
+        { 
+            value: '/foo/bar',
+            data: {
+                bar: 'a',
+                foo: 'b'
+            } 
+        }
+    ]);
+
+    const result = JSON.parse(JSON.stringify(podlet));
+
+    t.same(result.js, [{ 
+        type: 'default', 
+        value: '/foo/bar',
+        data: [
+            {
+                key: 'bar',
+                value: 'a',
+            },
+            {
+                key: 'foo',
+                value: 'b',
+            }
+        ] 
+    }]);
+    t.end()
+});
+
 // #############################################
 // .process()
 // #############################################


### PR DESCRIPTION
This adds support for setting data attributes through the `.js()` method like so:

```js
podlet.js([
    { 
        value: '/assets/script.js',
        data: {
            bar: 'a',
            foo: 'b'
        } 
    }
]);
```

This will then be represented in the html template like so:

```html
<script src="/assets/script.js" data-bar="a" data-foo="b"></script>
```

Originally suggested in https://github.com/podium-lib/utils/pull/58