### PR TITLE
feat: filter assets by scope if scope is provided

### DIFF
--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -329,12 +329,12 @@ const PodiumPodlet = class PodiumPodlet {
         incoming.name = this.name;
         incoming.css = this.cssRoute.filter(
             ({ scope = 'all' }) =>
-                scope === this[_currentScope](incoming.url.pathname) ||
+                scope === this[_currentScope](incoming) ||
                 scope === 'all',
         );
         incoming.js = this.jsRoute.filter(
             ({ scope = 'all' }) =>
-                scope === this[_currentScope](incoming.url.pathname) ||
+                scope === this[_currentScope](incoming) ||
                 scope === 'all',
         );
 
@@ -426,9 +426,20 @@ const PodiumPodlet = class PodiumPodlet {
         return result.length === 0 ? '' : result[0];
     }
 
-    [_currentScope](url) {
-        if (this.content({ prefix: true }) === url) return 'content';
-        if (this.fallback({ prefix: true }) === url) return 'fallback';
+    [_currentScope](incoming) {
+        const fallback = this.fallback({ prefix: true });
+        const content = this.content({ prefix: true });
+        const { pathname } = incoming.url;
+
+        // only check fallback if defined
+        // match fallback first since fallback is a more accurate match since
+        // fallback cannot take dynamic path segments and we can use exact matching
+        if (!!fallback && pathname === fallback) return 'fallback';
+
+        // fallback didn't match so check content
+        // we have to use startsWith since content may contain dynamic path segments
+        if (pathname.startsWith(content)) return 'content';
+
         return 'all';
     }
 };

--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -25,6 +25,7 @@ const _compatibility = Symbol('_compatibility');
 const _sanitize = Symbol('_sanitize');
 const _addCssAsset = Symbol('_addCssAsset');
 const _addJsAsset = Symbol('_addJsAsset');
+const _currentScope = Symbol('_currentScope');
 
 const PodiumPodlet = class PodiumPodlet {
     constructor({
@@ -326,8 +327,16 @@ const PodiumPodlet = class PodiumPodlet {
 
     async process(incoming, { proxy = true } = {}) {
         incoming.name = this.name;
-        incoming.css = this.cssRoute;
-        incoming.js = this.jsRoute;
+        incoming.css = this.cssRoute.filter(
+            ({ scope = 'all' }) =>
+                scope === this[_currentScope](incoming.url.pathname) ||
+                scope === 'all',
+        );
+        incoming.js = this.jsRoute.filter(
+            ({ scope = 'all' }) =>
+                scope === this[_currentScope](incoming.url.pathname) ||
+                scope === 'all',
+        );
 
         // Determine if request comes from layout server or not
         if (
@@ -415,6 +424,12 @@ const PodiumPodlet = class PodiumPodlet {
             return o.value;
         });
         return result.length === 0 ? '' : result[0];
+    }
+
+    [_currentScope](url) {
+        if (this.content({ prefix: true }) === url) return 'content';
+        if (this.fallback({ prefix: true }) === url) return 'fallback';
+        return 'all';
     }
 };
 

--- a/tests/podlet.js
+++ b/tests/podlet.js
@@ -1416,3 +1416,87 @@ test('Asset scope filtering - pathname "/foo" and content "/bar"', async (t) => 
     await server.close();
     t.end();
 });
+
+test('Asset scope filtering - pathname "/foo" and fallback "/"', async (t) => {
+    t.plan(2);
+    const podlet = new Podlet({
+        name: 'test',
+        version: '1.0.0',
+        pathname: '/foo',
+        content: '/content',
+        fallback: '/',
+    });
+    podlet.js([
+        new AssetJs({ value: '/foo', scope: 'content' }),
+        new AssetJs({ value: '/bar', scope: 'fallback' }),
+        new AssetJs({ value: '/baz', scope: 'all' }),
+        new AssetJs({ value: '/foobar' }),
+    ]);
+
+    const server = new FakeExpressServer(podlet, null, async (req, res) => {
+        t.equal(res.locals.podium.js.length, 3);
+        t.equal(res.locals.podium.js[0].scope, 'content');
+        res.send({ ok: true });
+    });
+
+    await server.listen();
+    await server.get({ path: '/foo/content' });
+    await server.close();
+    t.end();
+});
+
+test('Asset scope filtering - fallback "/"', async (t) => {
+    t.plan(2);
+    const podlet = new Podlet({
+        name: 'test',
+        version: '1.0.0',
+        pathname: '/',
+        content: '/content',
+        fallback: '/',
+    });
+    podlet.js([
+        new AssetJs({ value: '/foo', scope: 'content' }),
+        new AssetJs({ value: '/bar', scope: 'fallback' }),
+        new AssetJs({ value: '/baz', scope: 'all' }),
+        new AssetJs({ value: '/foobar' }),
+    ]);
+
+    const server = new FakeExpressServer(podlet, null, null, async (req, res) => {
+        t.equal(res.locals.podium.js.length, 3);
+        t.equal(res.locals.podium.js[0].scope, 'fallback');
+        res.send({ ok: true });
+    });
+
+    await server.listen();
+    await server.get();
+    await server.close();
+    t.end();
+});
+
+test('Asset scope filtering - pathname "/foo" and fallback "/"', async (t) => {
+    t.plan(2);
+    const podlet = new Podlet({
+        name: 'test',
+        version: '1.0.0',
+        pathname: '/foo',
+        content: '/content',
+        fallback: '/',
+    });
+    podlet.js([
+        new AssetJs({ value: '/foo', scope: 'content' }),
+        new AssetJs({ value: '/bar', scope: 'fallback' }),
+        new AssetJs({ value: '/baz', scope: 'all' }),
+        new AssetJs({ value: '/foobar' }),
+    ]);
+
+    const server = new FakeExpressServer(podlet, null, null, async (req, res) => {
+        t.equal(res.locals.podium.js.length, 3);
+        t.equal(res.locals.podium.js[0].scope, 'fallback');
+        res.send({ ok: true });
+    });
+
+    await server.listen();
+    await server.get({ path: '/foo' });
+    await server.close();
+    t.end();
+});

--- a/tests/podlet.js
+++ b/tests/podlet.js
@@ -98,9 +98,11 @@ class FakeHttpServer {
 }
 
 class FakeExpressServer {
-    constructor(podlet, onRequest) {
+    constructor(podlet, onRequest, onContentRoute, onFallbackRoute) {
         this.app = express();
         this.app.use(podlet.middleware());
+        if (onContentRoute) this.app.get(podlet.content({ prefix: true }), onContentRoute);
+        if (onFallbackRoute) this.app.get(podlet.fallback({ prefix: true }), onFallbackRoute);
         this.app.use(
             onRequest ||
                 ((req, res) => {
@@ -1269,4 +1271,148 @@ test('.metrics - assigned object to property - should have object tag with "Metr
     const podlet = new Podlet(DEFAULT_OPTIONS);
     t.equal(Object.prototype.toString.call(podlet.metrics), '[object MetricsClient]');
     t.end()
+});
+
+// #############################################
+// scope
+// #############################################
+
+test('Asset scope filtering - pathname and content both "/"', async (t) => {
+    t.plan(2);
+    const podlet = new Podlet({
+        name: 'test',
+        version: '1.0.0',
+        pathname: '/',
+        content: '/',
+    });
+    podlet.js([
+        new AssetJs({ value: '/foo', scope: 'content' }),
+        new AssetJs({ value: '/bar', scope: 'fallback' }),
+        new AssetJs({ value: '/baz', scope: 'all' }),
+        new AssetJs({ value: '/foobar' }),
+    ]);
+
+    const server = new FakeExpressServer(podlet, async (req, res) => {
+        t.equal(res.locals.podium.js.length, 3);
+        t.equal(res.locals.podium.js[0].scope, 'content');
+        res.send({ ok: true });
+    });
+
+    await server.listen();
+    await server.get();
+    await server.close();
+    t.end();
+});
+
+test('Asset scope filtering - pathname "/" and fallback "/fallback"', async (t) => {
+    t.plan(2);
+    const podlet = new Podlet({
+        name: 'test',
+        version: '1.0.0',
+        pathname: '/',
+        fallback: '/fallback',
+    });
+    podlet.js([
+        new AssetJs({ value: '/foo', scope: 'content' }),
+        new AssetJs({ value: '/bar', scope: 'fallback' }),
+        new AssetJs({ value: '/baz', scope: 'all' }),
+        new AssetJs({ value: '/foobar' }),
+    ]);
+
+    const server = new FakeExpressServer(
+        podlet,
+        null,
+        null,
+        async (req, res) => {
+            t.equal(res.locals.podium.js.length, 3);
+            t.equal(res.locals.podium.js[0].scope, 'fallback');
+            res.send({ ok: true });
+        },
+    );
+
+    await server.listen();
+    await server.get({ path: '/fallback' });
+    await server.close();
+    t.end();
+});
+
+test('Asset scope filtering - pathname "/" and content "/content"', async (t) => {
+    t.plan(2);
+    const podlet = new Podlet({
+        name: 'test',
+        version: '1.0.0',
+        pathname: '/',
+        content: '/content',
+    });
+    podlet.js([
+        new AssetJs({ value: '/foo', scope: 'content' }),
+        new AssetJs({ value: '/bar', scope: 'fallback' }),
+        new AssetJs({ value: '/baz', scope: 'all' }),
+        new AssetJs({ value: '/foobar' }),
+    ]);
+
+    const server = new FakeExpressServer(podlet, null, async (req, res) => {
+        t.equal(res.locals.podium.js.length, 3);
+        t.equal(res.locals.podium.js[0].scope, 'content');
+        res.send({ ok: true });
+    });
+
+    await server.listen();
+    await server.get({ path: '/content' });
+    await server.close();
+    t.end();
+});
+
+test('Asset scope filtering - pathname "/foo" and content "/"', async (t) => {
+    t.plan(2);
+    const podlet = new Podlet({
+        name: 'test',
+        version: '1.0.0',
+        pathname: '/foo',
+        content: '/',
+    });
+    podlet.js([
+        new AssetJs({ value: '/foo', scope: 'content' }),
+        new AssetJs({ value: '/bar', scope: 'fallback' }),
+        new AssetJs({ value: '/baz', scope: 'all' }),
+        new AssetJs({ value: '/foobar' }),
+    ]);
+
+    const server = new FakeExpressServer(podlet, null, async (req, res) => {
+        t.equal(res.locals.podium.js.length, 3);
+        t.equal(res.locals.podium.js[0].scope, 'content');
+        res.send({ ok: true });
+    });
+
+    await server.listen();
+    await server.get({ path: '/foo' });
+    await server.close();
+    t.end();
+});
+
+test('Asset scope filtering - pathname "/foo" and content "/bar"', async (t) => {
+    t.plan(2);
+    const podlet = new Podlet({
+        name: 'test',
+        version: '1.0.0',
+        pathname: '/foo',
+        content: '/content',
+    });
+    podlet.js([
+        new AssetJs({ value: '/foo', scope: 'content' }),
+        new AssetJs({ value: '/bar', scope: 'fallback' }),
+        new AssetJs({ value: '/baz', scope: 'all' }),
+        new AssetJs({ value: '/foobar' }),
+    ]);
+
+    const server = new FakeExpressServer(podlet, null, async (req, res) => {
+        t.equal(res.locals.podium.js.length, 3);
+        t.equal(res.locals.podium.js[0].scope, 'content');
+        res.send({ ok: true });
+    });
+
+    await server.listen();
+    await server.get({ path: '/foo/content' });
+    await server.close();
+    t.end();
 });


### PR DESCRIPTION
This PR adds development support for the new scope feature of asset objects.

Scope is handled in the Podium client in prod but in local development it needs to work as well so this PR adds asset filtering based on scope (content or fallback)

The defined content and fallback routes are matched against the request pathname to determine if a route is a content route of a fallback route. Once determined, it can then be compared against each asset object's scope property.