### PR TITLE
ci: Fix semantic release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
   - name: Setup Node.js
     uses: actions/setup-node@v4
     with:
-      node-version: 16.x
+      node-version: 20.x
   - name: npm install
     run: |
       npm install
@@ -38,7 +38,7 @@ jobs:
   - name: Setup Node.js
     uses: actions/setup-node@v4
     with:
-      node-version: 16.x
+      node-version: 20.x
   - name: npm install
     run: |
       npm install


### PR DESCRIPTION
Releasing is broken due to "old" node version: https://github.com/podium-lib/podlet/actions/runs/7084375936/job/19278572667#step:5:8