### PR TITLE
Pass params to http incoming

### DIFF
--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -903,7 +903,10 @@ export default class PodiumPodlet {
      */
     middleware() {
         return async (req, res, next) => {
-            const incoming = new HttpIncoming(req, res);
+            // initialise res.locals.params so that it can be added to anywhere including in route hooks
+            // or middleware added after this middleware
+            res.locals.params = res.locals.params || {};
+            const incoming = new HttpIncoming(req, res, res.locals.params);
             // @ts-ignore
             incoming.url = new URL(
                 req.originalUrl,

--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -903,10 +903,7 @@ export default class PodiumPodlet {
      */
     middleware() {
         return async (req, res, next) => {
-            // initialise res.locals.params so that it can be added to anywhere including in route hooks
-            // or middleware added after this middleware
-            res.locals.params = res.locals.params || {};
-            const incoming = new HttpIncoming(req, res, res.locals.params);
+            const incoming = new HttpIncoming(req, res, res.locals);
             // @ts-ignore
             incoming.url = new URL(
                 req.originalUrl,

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "eslint-plugin-import": "2.29.1",
     "eslint-plugin-prettier": "5.1.3",
     "express": "4.19.2",
+    "json-stringify-safe": "5.0.1",
     "prettier": "3.2.4",
     "semantic-release": "23.0.6",
     "tap": "18.7.2",

--- a/tests/podlet.js
+++ b/tests/podlet.js
@@ -1303,6 +1303,24 @@ tap.test('.view() - append a custom wireframe document - should render developme
     await server.close();
 });
 
+tap.test('.view() - append a custom wireframe document - should render development output with custom wireframe document', async (t) => {
+    const options = { ...DEFAULT_OPTIONS, development: true };
+
+    const podlet = new Podlet(options);
+    podlet.view((incoming, data) => `<div data-foo="${incoming.params.foo}">${data}</div>`);
+
+    const server = new FakeExpressServer(podlet, (req, res) => {
+        res.locals.params.foo = 'bar';
+        res.podiumSend('<h1>OK!</h1>');
+    });
+
+    await server.listen();
+    const result = await server.get({ raw: true });
+
+    t.equal(result.response, '<div data-foo="bar"><h1>OK!</h1></div>');
+    await server.close();
+});
+
 // #############################################
 // .metrics()
 // #############################################

--- a/tests/podlet.js
+++ b/tests/podlet.js
@@ -1,11 +1,13 @@
 // @ts-nocheck
 
+/* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable no-unused-expressions */
 /* eslint-disable max-classes-per-file */
 /* eslint-disable no-param-reassign */
 
 import { destinationObjectStream } from '@podium/test-utils';
 import { template, HttpIncoming, AssetJs, AssetCss } from '@podium/utils';
+import stringify from 'json-stringify-safe';
 import { join, dirname } from 'path';
 import Metrics from '@metrics/client';
 import tap from 'tap';
@@ -120,7 +122,7 @@ class FakeExpressServer {
         this.app.use(
             onRequest ||
                 ((req, res) => {
-                    res.status(200).json(res.locals);
+                    res.status(200).send(stringify(res.locals));
                 }),
         );
         this.server = undefined;
@@ -1310,7 +1312,8 @@ tap.test('.view() - append a custom wireframe document - should render developme
     podlet.view((incoming, data) => `<div data-foo="${incoming.params.foo}">${data}</div>`);
 
     const server = new FakeExpressServer(podlet, (req, res) => {
-        res.locals.params.foo = 'bar';
+        res.locals.params = res.locals.params || {};
+        res.locals.foo = 'bar';
         res.podiumSend('<h1>OK!</h1>');
     });
 

--- a/tests/podlet.js
+++ b/tests/podlet.js
@@ -1312,7 +1312,6 @@ tap.test('.view() - append a custom wireframe document - should render developme
     podlet.view((incoming, data) => `<div data-foo="${incoming.params.foo}">${data}</div>`);
 
     const server = new FakeExpressServer(podlet, (req, res) => {
-        res.locals.params = res.locals.params || {};
         res.locals.foo = 'bar';
         res.podiumSend('<h1>OK!</h1>');
     });


### PR DESCRIPTION
The podlet was not passing res.locals to HttpIncoming which is something we do in the layout as well as both the Fastify layout and podlet. 

Fixing this will make it easier to handle locale and other request bound values in the document template as prior to this fix, we couldn't rely on params being set, eg. incoming.params.locale was not available in the podlet context.