### PR TITLE
fix: update @podium/utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@metrics/client": "2.5.3",
     "@podium/proxy": "5.0.24",
     "@podium/schemas": "5.0.6",
-    "@podium/utils": "5.1.0",
+    "@podium/utils": "5.2.0",
     "abslog": "2.4.4",
     "ajv": "8.17.1",
     "objobj": "1.0.0"

--- a/tests/podlet.test.js
+++ b/tests/podlet.test.js
@@ -1928,7 +1928,7 @@ tap.test('assets - .js() - should send 103 Early hints', async (t) => {
     res.hints((info) => {
         t.equal(
             info.link,
-            '</scripts.js>; async=true; type=module; data-foo=bar',
+            '</scripts.js>; async=true; type=module; data-foo=bar; asset-type=script',
         );
     });
     await res.result();
@@ -1961,7 +1961,7 @@ tap.test(
         res.hints((info) => {
             t.equal(
                 info.link,
-                '</styles1.css>; type=text/css; rel=stylesheet; scope=content',
+                '</styles1.css>; type=text/css; rel=stylesheet; scope=content; asset-type=style',
             );
         });
         await res.result();
@@ -1996,7 +1996,7 @@ tap.test(
         res.hints((info) => {
             t.equal(
                 info.link,
-                '</styles2.css>; type=text/css; rel=stylesheet; scope=fallback',
+                '</styles2.css>; type=text/css; rel=stylesheet; scope=fallback; asset-type=style',
             );
         });
         await res.result();
@@ -2034,7 +2034,7 @@ tap.test(
         res.hints((info) => {
             t.equal(
                 info.link,
-                '</scripts.js>; async=true; type=module; data-foo=bar; scope=content, </styles.css>; type=text/css; rel=stylesheet; scope=content',
+                '</scripts.js>; async=true; type=module; data-foo=bar; scope=content; asset-type=script, </styles.css>; type=text/css; rel=stylesheet; scope=content; asset-type=style',
             );
         });
         await res.result();


### PR DESCRIPTION
This brings in the @podium/utils asset-type link header attribute which makes it easier for serialisation/deserialisation of asset objects to and from a link header. The podlet writes an asset-type attribute and the Podium client can then use it to tell which type of asset objects to create from the header