### PR TITLE
DSD Shadow dom

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,16 +79,17 @@ const podlet = new Podlet(options);
 
 ### options
 
-| option      | type      | default          | required |
-| ----------- | --------- | ---------------- | -------- |
-| name        | `string`  |                  | &check;  |
-| version     | `string`  |                  | &check;  |
-| pathname    | `string`  |                  | &check;  |
-| manifest    | `string`  | `/manifest.json` |          |
-| content     | `string`  | `/`              |          |
-| fallback    | `string`  |                  |          |
-| logger      | `object`  |                  |          |
-| development | `boolean` | `false`          |          |
+| option       | type      | default          | required |
+| ------------ | --------- | ---------------- | -------- |
+| name         | `string`  |                  | &check;  |
+| version      | `string`  |                  | &check;  |
+| pathname     | `string`  |                  | &check;  |
+| manifest     | `string`  | `/manifest.json` |          |
+| content      | `string`  | `/`              |          |
+| fallback     | `string`  |                  |          |
+| logger       | `object`  |                  |          |
+| development  | `boolean` | `false`          |          |
+| useShadowDOM | `boolean` | `false`          |          |
 
 #### name
 
@@ -256,6 +257,52 @@ further details.
 #### development
 
 Turns development mode on or off. See the section about development mode.
+
+#### useShadowDOM
+
+Turns declarative shadow DOM encapsulation on for the podlet. When enabled, the podlet content will be wrapped inside a declarative shadow DOM wrapper to isolate it from the rest of whichever
+page it is being included on.
+
+```js
+const podlet = new Podlet({ ..., useShadowDOM: true });
+```
+
+Please note the following caveats when using this feature:
+1. You must name your podlet following custom element naming conventions as explained here: https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define#valid_custom_element_names
+2. In order to style your content, you will need to include your CSS inside the shadow DOM wrapper. You can do this using one of the following 2 options:
+
+You can include a `<style>` tag before your content
+
+```js
+res.podiumSend(`
+	<style>
+		...styles here...
+	</style>
+	<div>...content here...</div>
+`);
+```
+
+You can have your podlet CSS included for you by using the "shadow-dom" scope
+
+```js
+podlet.css({ value: '/path/to/css', scope: 'shadow-dom' });
+res.podiumSend(`
+	<div>...content here...</div>
+`);
+```
+
+For more fine grained control, you can use the `podlet.wrapWithShadowDOM` method directly
+
+```js
+const podlet = new Podlet({ ..., useShadowDOM: false });
+```
+
+```js
+const wrapped = podlet.wrapWithShadowDOM(`<div>...content here...</div>`);
+res.podiumSend(`
+	${wrapped}
+`);
+```
 
 ## Podlet Instance
 

--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -288,6 +288,9 @@ export default class PodiumPodlet {
      */
     metrics = new Metrics();
 
+    /**
+     * Boolean flag that, when true, enables the use of declarative ShadowDOM in the podlet.
+     */
     #useShadowDOM = false;
 
     /**
@@ -301,6 +304,7 @@ export default class PodiumPodlet {
      * * `content` - path where the podlet content HTML markup is served from (**default** `'/'`)
      * * `fallback` - path where the podlet fallback HTML markup is served from (**default** `'/fallback'`)
      * * `development` - a boolean flag that, when true, enables additional development setup (**default** `false`)
+     * * `useShadowDOM` - a boolean flag that, when true, enables the use of declarative ShadowDOM in the podlet (**default** `false`)
      * * `logger` - a logger to use when provided. Can be the console object if console logging is desired but can also be any Log4j compatible logging object as well. Nothing is logged if no logger is provided. (**default** `null`)
      * * `proxy` - options that can be provided to configure the @podium/proxy instance used by the podlet. See that module for details. (**default**: `{}`)
      *
@@ -827,6 +831,15 @@ export default class PodiumPodlet {
         return this.#view(incoming, markup, ...args);
     }
 
+    /**
+     * Function that takes in the podlet content,wraps it in declarative shadow DOM and returns it.
+     * @param {string} data - the podlet content to wrap in declarative shadow DOM as an HTML markup string
+     *
+     * @example
+     * ```js
+     * const content = podlet.wrapWithShadowDOM('<div>content to render</div>');
+     * ```
+     */
     wrapWithShadowDOM(data) {
         assert.ok(
             customElementRegex.test(this.name),

--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -15,6 +15,11 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 // @ts-ignore
 import fs from 'node:fs';
+import { wrap } from '@hide-in-shadows/html';
+import assert from 'node:assert';
+
+const customElementRegex =
+    /^(?!(annotation-xml|color-profile|font-face|font-face-src|font-face-uri|font-face-format|font-face-name|missing-glyph)$)[a-z][a-z0-9.-]*-[a-z0-9.-]*$/;
 
 const currentDirectory = dirname(fileURLToPath(import.meta.url));
 const pkgJson = fs.readFileSync(
@@ -283,6 +288,8 @@ export default class PodiumPodlet {
      */
     metrics = new Metrics();
 
+    #useShadowDOM = false;
+
     /**
      * Creates a new instance of a Podium podlet which can be used in conjunction with your framework of choice to build podlet server apps.
      * `name`, `version` and `pathname` constructor arguments are required. All other options are optional.
@@ -317,6 +324,7 @@ export default class PodiumPodlet {
         logger = undefined,
         development = false,
         proxy = {},
+        useShadowDOM = false,
     }) {
         if (schema.name(name).error)
             throw new Error(
@@ -374,6 +382,7 @@ export default class PodiumPodlet {
                 this.name,
             ),
         };
+        this.#useShadowDOM = useShadowDOM;
 
         // Skip a tick to ensure the metric stream has been consumed
         setImmediate(() => {
@@ -811,10 +820,40 @@ export default class PodiumPodlet {
      * @returns {string}
      */
     render(incoming, data, ...args) {
+        const markup = this.#useShadowDOM
+            ? this.wrapWithShadowDOM(incoming, data)
+            : data;
         if (!incoming.development) {
+            return markup;
+        }
+        return this.#view(incoming, markup, ...args);
+    }
+
+    wrapWithShadowDOM(incoming, data, { mode = 'open' }) {
+        // This is an idea I had to allow the layout to disable podlet isolation via a context value.
+        if (incoming.context.isolate === false) {
             return data;
         }
-        return this.#view(incoming, data, ...args);
+
+        assert.ok(
+            customElementRegex.test(this.name),
+            'When using isolation, podlet.name must conform to custom element naming conventions: https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define#valid_custom_element_names',
+        );
+
+        const styles = this.cssRoute
+            .filter((css) => css.scope === 'shadow-dom' || css.scope === 'all')
+            .map((css) => `@import url('${css.value}');`);
+
+        // we use the style urls to build CSS @import statements that we place inside a style tag. This should ensure that styles are loaded before the content is rendered.
+        let styleTag = '';
+        if (styles.length) {
+            styleTag = `<style>${styles.join('')}</style>`;
+        }
+
+        // I can't see a reason to include support for scripts inside the DSD so have omitted.
+
+        // Finally, we wrap the markup in the DSD tag. We could use hide in shadows or we could inline what hide in shadows does (which isn't all that much) to avoid the dependency.
+        return wrap(this.name, `${styleTag}${data}`, { mode });
     }
 
     /**

--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -15,7 +15,6 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 // @ts-ignore
 import fs from 'node:fs';
-import { wrap } from '@hide-in-shadows/html';
 import assert from 'node:assert';
 
 const customElementRegex =
@@ -35,16 +34,17 @@ const { template } = utils;
  * @property {string} name - (required) podlet name
  * @property {string} version - (required) podlet version
  * @property {string} pathname - (required) podlet pathname
- * @property {string} [manifest] - path where the podlet manifest file is served from (default '/manifest.json')
- * @property {string} [content] - path where the podlet content HTML markup is served from (default '/')
- * @property {string} [fallback] - path where the podlet fallback HTML markup is served from (default '/fallback')
- * @property {boolean} [development] - a boolean flag that, when true, enables additional development setup (default false)
+ * @property {string} [manifest='/manifest.json'] - path where the podlet manifest file is served from (default '/manifest.json')
+ * @property {string} [content='/'] - path where the podlet content HTML markup is served from (default '/')
+ * @property {string} [fallback=''] - path where the podlet fallback HTML markup is served from (default '/fallback')
+ * @property {boolean} [development=false] - a boolean flag that, when true, enables additional development setup (default false)
+ * @property {boolean} [useShadowDOM=false] - a boolean flag that, when true, enables the use of ShadowDOM (default false)
  * @property {import('abslog').AbstractLoggerOptions} [logger] - a logger to use when provided. Can be the console object if console logging is desired but can also be any Log4j compatible logging object as well. Nothing is logged if no logger is provided. (default null)
  * @property {import("@podium/proxy").PodiumProxyOptions} [proxy] - options that can be provided to configure the @podium/proxy instance used by the podlet. See that module for details.
  *
  * @typedef {{ debug: 'true' | 'false', locale: string, deviceType: string, requestedBy: string, mountOrigin: string, mountPathname: string, publicPathname: string }} PodletContext
- * @typedef {{ as?: string | false | null, crossorigin?: string | null | boolean, disabled?: boolean | '' | null, hreflang?: string | false | null, title?: string | false | null, media?: string | false | null, rel?: string | false | null, type?: string | false | null, value: string | false | null, strategy?: "beforeInteractive" | "afterInteractive" | "lazy", scope?: "content" | "fallback" | "all", [key: string]: any }} AssetCssLike
- * @typedef {{ value: string | null, crossorigin?: string | null | boolean, type?: string | null | false, integrity?: string | null | false, referrerpolicy?: string | null | false, nomodule?: boolean | null | '', async?: boolean | null | '', defer?: boolean | null | '', data?: {[key: string]: string} | Array<{ key: string; value: string }>, strategy?: "beforeInteractive" | "afterInteractive" | "lazy", scope?: "content" | "fallback" | "all", [key: string]: any }} AssetJsLike
+ * @typedef {{ as?: string | false | null, crossorigin?: string | null | boolean, disabled?: boolean | '' | null, hreflang?: string | false | null, title?: string | false | null, media?: string | false | null, rel?: string | false | null, type?: string | false | null, value: string | false | null, strategy?: "beforeInteractive" | "afterInteractive" | "lazy", scope?: "content" | "fallback" | "all" | "shadow-dom", [key: string]: any }} AssetCssLike
+ * @typedef {{ value: string | null, crossorigin?: string | null | boolean, type?: string | null | false, integrity?: string | null | false, referrerpolicy?: string | null | false, nomodule?: boolean | null | '', async?: boolean | null | '', defer?: boolean | null | '', data?: {[key: string]: string} | Array<{ key: string; value: string }>, strategy?: "beforeInteractive" | "afterInteractive" | "lazy", scope?: "content" | "fallback" | "all" | "shadow-dom", [key: string]: any }} AssetJsLike
  */
 
 export default class PodiumPodlet {
@@ -820,40 +820,41 @@ export default class PodiumPodlet {
      * @returns {string}
      */
     render(incoming, data, ...args) {
-        const markup = this.#useShadowDOM
-            ? this.wrapWithShadowDOM(incoming, data)
-            : data;
+        const markup = this.#useShadowDOM ? this.wrapWithShadowDOM(data) : data;
         if (!incoming.development) {
             return markup;
         }
         return this.#view(incoming, markup, ...args);
     }
 
-    wrapWithShadowDOM(incoming, data, { mode = 'open' }) {
-        // This is an idea I had to allow the layout to disable podlet isolation via a context value.
-        if (incoming.context.isolate === false) {
-            return data;
-        }
-
+    wrapWithShadowDOM(data) {
         assert.ok(
             customElementRegex.test(this.name),
             'When using isolation, podlet.name must conform to custom element naming conventions: https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define#valid_custom_element_names',
         );
 
         const styles = this.cssRoute
-            .filter((css) => css.scope === 'shadow-dom' || css.scope === 'all')
-            .map((css) => `@import url('${css.value}');`);
+            .filter((css) => css.scope === 'shadow-dom')
+            .map((css) => css.toHTML());
 
-        // we use the style urls to build CSS @import statements that we place inside a style tag. This should ensure that styles are loaded before the content is rendered.
-        let styleTag = '';
-        if (styles.length) {
-            styleTag = `<style>${styles.join('')}</style>`;
-        }
+        const scripts = this.jsRoute
+            .filter((js) => js.scope === 'shadow-dom')
+            .map((js) => js.toHTML());
 
-        // I can't see a reason to include support for scripts inside the DSD so have omitted.
-
-        // Finally, we wrap the markup in the DSD tag. We could use hide in shadows or we could inline what hide in shadows does (which isn't all that much) to avoid the dependency.
-        return wrap(this.name, `${styleTag}${data}`, { mode });
+        // Wrap the markup in DSD.
+        return `
+          <${this.name}>
+            <template shadowrootmode="open">
+              ${styles.join('\n')}
+              ${data}
+              ${scripts.join('\n')}
+            </template>
+          </${this.name}>
+          <script>(()=>{function e(d){HTMLTemplateElement.prototype.hasOwnProperty("shadowRootMode")||d.querySelectorAll("template[shadowrootmode]").forEach(o=>{let
+          n=o.getAttribute("shadowrootmode"),s=o.hasAttribute("shadowrootdelegatesfocus"),t=o.parentNode.attachShadow({mode:n,delegatesFocus:s});t.appendChild(o.content),o.remove(),e(t)})}var
+          r;(r=document.currentScript)!=null&&r.previousElementSibling&&e(document.currentScript.previousElementSibling);})();
+          </script>
+        `;
     }
 
     /**

--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -830,7 +830,7 @@ export default class PodiumPodlet {
     wrapWithShadowDOM(data) {
         assert.ok(
             customElementRegex.test(this.name),
-            'When using isolation, podlet.name must conform to custom element naming conventions: https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define#valid_custom_element_names',
+            'When using the constructor argument "useShadowDOM", podlet.name must conform to custom element naming conventions: https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define#valid_custom_element_names',
         );
 
         const styles = this.cssRoute

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "types:fixup": "node ./fixup.js"
   },
   "dependencies": {
+    "@hide-in-shadows/html": "0.0.5",
     "@metrics/client": "2.5.3",
     "@podium/proxy": "5.0.24",
     "@podium/schemas": "5.0.6",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "types:fixup": "node ./fixup.js"
   },
   "dependencies": {
-    "@hide-in-shadows/html": "0.0.5",
     "@metrics/client": "2.5.3",
     "@podium/proxy": "5.0.24",
     "@podium/schemas": "5.0.6",

--- a/tests/podlet.test.js
+++ b/tests/podlet.test.js
@@ -2041,3 +2041,87 @@ tap.test(
         await server.close();
     },
 );
+
+// #############################################
+// Wrap content using shadow DOM
+// #############################################
+
+tap.test(
+    'useShadowDOM - use of useShadowDOM flag - should render content inside shadow DOM',
+    async (t) => {
+        const options = {
+            ...DEFAULT_OPTIONS,
+            name: 'my-podlet',
+            useShadowDOM: true,
+        };
+
+        const podlet = new Podlet(options);
+
+        const server = new FakeExpressServer(podlet, (req, res) => {
+            res.podiumSend('<h1>OK!</h1>');
+        });
+
+        await server.listen();
+        const result = await server.get({ raw: true });
+
+        t.match(
+            result.response.replaceAll(/\s+/g, ''),
+            /<my-podlet><templateshadowrootmode="open"><h1>OK!<\/h1><\/template><\/my-podlet>/,
+        );
+        await server.close();
+    },
+);
+
+tap.test(
+    'useShadowDOM - css assets with shadow-dom scope - should render link tags inside shadow DOM',
+    async (t) => {
+        const options = {
+            ...DEFAULT_OPTIONS,
+            name: 'my-podlet',
+            useShadowDOM: true,
+        };
+
+        const podlet = new Podlet(options);
+        podlet.css({ value: '/foo', scope: 'shadow-dom' });
+
+        const server = new FakeExpressServer(podlet, (req, res) => {
+            res.podiumSend('<h1>OK!</h1>');
+        });
+
+        await server.listen();
+        const result = await server.get({ raw: true });
+
+        t.match(
+            result.response.replaceAll(/\s+/g, ''),
+            /<my-podlet><templateshadowrootmode="open"><linkhref="\/foo"type="text\/css"rel="stylesheet"><h1>OK!<\/h1><\/template><\/my-podlet>/,
+        );
+        await server.close();
+    },
+);
+
+tap.test(
+    'useShadowDOM - css assets with all scope - should not render link tags inside shadow DOM',
+    async (t) => {
+        const options = {
+            ...DEFAULT_OPTIONS,
+            name: 'my-podlet',
+            useShadowDOM: true,
+        };
+
+        const podlet = new Podlet(options);
+        podlet.css({ value: '/foo', scope: 'all' });
+
+        const server = new FakeExpressServer(podlet, (req, res) => {
+            res.podiumSend('<h1>OK!</h1>');
+        });
+
+        await server.listen();
+        const result = await server.get({ raw: true });
+
+        t.match(
+            result.response.replaceAll(/\s+/g, ''),
+            /<my-podlet><templateshadowrootmode="open"><h1>OK!<\/h1><\/template><\/my-podlet>/,
+        );
+        await server.close();
+    },
+);


### PR DESCRIPTION
This PR is a second attempt (after feedback) for implementing DSD wrapping for podlets.

A new constructor argument has been added

```js
const podlet = new Podlet({
  name: 'my-podlet', // when useShadowDOM is set to true, name must be valid custom element name
  useShadowDOM: true,
});
```

and asset scopes can be used to place assets inside the Shadow DOM.

```js
podlet.css({ value: '/path/to/css', scope: 'shadow-dom' });
```

For the base use case, thats all you need to do.