### PR TITLE
fix: tag asset type when sending hint headers

### DIFF
--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -935,11 +935,15 @@ export default class PodiumPodlet {
             await this.httpProxy.process(incoming);
         }
 
-        // @ts-ignore
-        const js = incoming.js.map((asset) => asset.toHeader());
+        const js = incoming.js.map(
+            // @ts-ignore
+            (asset) => asset.toHeader() + '; asset-type=script',
+        );
 
-        // @ts-ignore
-        const css = incoming.css.map((asset) => asset.toHeader());
+        const css = incoming.css.map(
+            // @ts-ignore
+            (asset) => asset.toHeader() + '; asset-type=style',
+        );
 
         // Send early hints to layout client in the form of a 103 status code and a link header with js/css asset information.
         // Always send this. If no assets present, send an empty string.

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@metrics/client": "2.5.3",
     "@podium/proxy": "5.0.24",
     "@podium/schemas": "5.0.6",
-    "@podium/utils": "5.2.0",
+    "@podium/utils": "5.2.1",
     "abslog": "2.4.4",
     "ajv": "8.17.1",
     "objobj": "1.0.0"


### PR DESCRIPTION
With utils 5.2.1, headers are no longer tagged with asset-type so we do that here in the podlet instead