### PR TITLE
fix: sharpen up shadow dom usage assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ const podlet = new Podlet(options);
 
 #### name
 
-The name the podlet identifies itself by. This value must be in camelCase.
+The name the podlet identifies itself by. This value can contain upper and lower case letters, numbers, the - character and the \_ character. No spaces.
+When shadow DOM is used, either via the `useShadowDOM` constructor option or via the `wrapWithShadowDOM` method, the name must comply with custom element naming rules.
+See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define#valid_custom_element_names) for more information.
 
 _Example:_
 
@@ -268,6 +270,7 @@ const podlet = new Podlet({ ..., useShadowDOM: true });
 ```
 
 Please note the following caveats when using this feature:
+
 1. You must name your podlet following custom element naming conventions as explained here: https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define#valid_custom_element_names
 2. In order to style your content, you will need to include your CSS inside the shadow DOM wrapper. You can do this using one of the following 2 options:
 

--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -841,12 +841,10 @@ export default class PodiumPodlet {
      * ```
      */
     wrapWithShadowDOM(data) {
-        if (!this.#useShadowDOM) {
-            assert.ok(
-                customElementRegex.test(this.name),
-                `When using the constructor argument "useShadowDOM" or the method podlet.wrapWithShadowDOM, podlet.name must conform to custom element naming conventions. The name "${this.name}" does not comply. See https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define#valid_custom_element_names for more information.`,
-            );
-        }
+        assert.ok(
+            customElementRegex.test(this.name),
+            `When using the constructor argument "useShadowDOM" or the method podlet.wrapWithShadowDOM, podlet.name must conform to custom element naming conventions. The name "${this.name}" does not comply. See https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define#valid_custom_element_names for more information.`,
+        );
 
         const styles = this.cssRoute
             .filter((css) => css.scope === 'shadow-dom')

--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -841,10 +841,12 @@ export default class PodiumPodlet {
      * ```
      */
     wrapWithShadowDOM(data) {
-        assert.ok(
-            customElementRegex.test(this.name),
-            'When using the constructor argument "useShadowDOM", podlet.name must conform to custom element naming conventions: https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define#valid_custom_element_names',
-        );
+        if (!this.#useShadowDOM) {
+            assert.ok(
+                customElementRegex.test(this.name),
+                `When using the constructor argument "useShadowDOM" or the method podlet.wrapWithShadowDOM, podlet.name must conform to custom element naming conventions. The name "${this.name}" does not comply. See https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define#valid_custom_element_names for more information.`,
+            );
+        }
 
         const styles = this.cssRoute
             .filter((css) => css.scope === 'shadow-dom')


### PR DESCRIPTION
re: Feedback from Dave H that it could be nice to include the invalid name in the message. I also saw that it was probably worth mentioning the use of the wrapWithShadowDOM method in case it is being used directly