### PR TITLE
Replace early hints

### DIFF
--- a/lib/podlet.js
+++ b/lib/podlet.js
@@ -935,24 +935,6 @@ export default class PodiumPodlet {
             await this.httpProxy.process(incoming);
         }
 
-        const js = incoming.js.map(
-            // @ts-ignore
-            (asset) => asset.toHeader() + '; asset-type=script',
-        );
-
-        const css = incoming.css.map(
-            // @ts-ignore
-            (asset) => asset.toHeader() + '; asset-type=style',
-        );
-
-        // Send early hints to layout client in the form of a 103 status code and a link header with js/css asset information.
-        // Always send this. If no assets present, send an empty string.
-        if (incoming.response.writeEarlyHints) {
-            incoming.response.writeEarlyHints({
-                link: [...js, ...css],
-            });
-        }
-
         return incoming;
     }
 
@@ -986,6 +968,18 @@ export default class PodiumPodlet {
                 // if this is a proxy request then no further work should be done.
                 if (incoming.proxy) return;
 
+                const js = incoming.js.map(
+                    // @ts-ignore
+                    (asset) => asset.toHeader() + '; asset-type=script',
+                );
+
+                const css = incoming.css.map(
+                    // @ts-ignore
+                    (asset) => asset.toHeader() + '; asset-type=style',
+                );
+
+                res.header('Link', [...js, ...css].join(', '));
+
                 // set "incoming" on res.locals.podium
                 objobj.set('locals.podium', incoming, res);
 
@@ -993,8 +987,15 @@ export default class PodiumPodlet {
                     res.header('podlet-version', this.version);
                 }
 
-                res.podiumSend = (data, ...args) =>
-                    res.send(this.render(incoming, data, ...args));
+                res.sendHeaders = () => {
+                    res.write('');
+                    return res;
+                };
+
+                res.podiumSend = (data, ...args) => {
+                    res.write(this.render(incoming, data, ...args));
+                    res.end();
+                };
 
                 next();
             } catch (error) {

--- a/tests/podlet.test.js
+++ b/tests/podlet.test.js
@@ -2019,7 +2019,7 @@ tap.test(
 tap.test(
     'assets - .js() and .css() - Link headers - should be sent before body',
     async (t) => {
-        t.plan(3);
+        t.plan(4);
         const podlet = new Podlet({
             name: 'foo',
             version: 'v1.0.0',
@@ -2046,6 +2046,7 @@ tap.test(
         });
 
         await server.listen();
+        let start = 0;
         const result = await server.get({
             raw: true,
             onHeaders(headers) {
@@ -2054,11 +2055,14 @@ tap.test(
                     '</scripts.js>; async=true; type=module; data-foo=bar; scope=content; asset-type=script, </styles.css>; type=text/css; rel=stylesheet; scope=content; asset-type=style',
                 );
                 orderArray.push('assets');
+                start = Date.now();
             },
         });
+        const timeTaken = Date.now() - start;
         orderArray.push('body');
         t.match(result.response, /<h1>OK!<\/h1>/);
         t.same(orderArray, ['assets', 'body']);
+        t.ok(timeTaken > 900);
         await server.close();
     },
 );


### PR DESCRIPTION
Early hints is a no go since some load balancers (eg. Google's load balancer in k8s) simply don't support early hints at all.

This PR does the next best thing which is to send the early hints as a Link header with all the other headers. It's slightly more awkward and by default there won't be a performance win at all but with a new method `res.sendHeaders` it becomes possible to send the headers first and the body afterwards. In both cases, assets will be sent request bound which is what we want.

### Default 

If the user does nothing except upgrade to this version of the podlet, assets will be sent request bound but there won't be a performance win...
```js
app.get(podlet.content(), (req, res) => {
    res.podiumSend('...');
});
```

### Additional syntax added to send assets to the layout early

The user can use the sendHeaders function to control when the headers are sent so that they can be sent before any heavy is work is done fetching the data for the podlet body etc.

```js
app.get(podlet.content(), (req, res) => {
    // use the new sendHeaders() function to send off the headers right away
    res.sendHeaders();
    // do some slow stuff...
    // and then call podiumSend as before
    res.podiumSend('...');
});
```

The reason we can't just send the headers automatically is that the user may need to modify the headers and once they've been sent, they can't be sent again.

eg.
```js
app.get(podlet.content(), (req, res) => {
    res.header('custom-header', 'custom-value');
    res.sendHeaders();
    // do some slow stuff...
    // and then call podiumSend as before
    res.podiumSend('...');
});
```